### PR TITLE
Fixes I18n::MissingTranslationData constructor

### DIFF
--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -37,7 +37,7 @@ module I18n
     attr_reader :locale, :key, :options
 
     def initialize(locale, key, opts = nil)
-      @key, @locale, @options = key, locale, opts.dup || {}
+      @key, @locale, @options = key, locale, (opts || {}).dup
       options.each { |k, v| options[k] = v.inspect if v.is_a?(Proc) }
       super "translation missing: #{keys.join('.')}"
     end

--- a/test/i18n/exceptions_test.rb
+++ b/test/i18n/exceptions_test.rb
@@ -77,6 +77,10 @@ class I18nExceptionsTest < Test::Unit::TestCase
       assert_equal 'reserved key :scope used in "%{scope}"', exception.message
     end
   end
+  
+  test "MissingTranslationData#new can be initialized with just two arguments" do
+    assert I18n::MissingTranslationData.new('en', 'key')
+  end
 
   private
 


### PR DESCRIPTION
The method signature is initialize(locale, key, opts = nil) which leaves opts as optional but the code was doing opts.dup
