### PR TITLE
Fallback to default_locale when locale was not specified

### DIFF
--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -3,7 +3,7 @@ module I18n
     # The only configuration value that is not global and scoped to thread is :locale.
     # It defaults to the default_locale.
     def locale
-      @locale ||= default_locale
+      @locale || default_locale
     end
 
     # Sets the current locale pseudo-globally, i.e. in the Thread.current hash.

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -39,6 +39,12 @@ class I18nTest < Test::Unit::TestCase
     assert_equal I18n.default_locale, I18n.locale
   end
 
+  test "uses the default locale as locale after being set" do
+    I18n.locale
+    I18n.default_locale = :pt
+    assert_equal :pt, I18n.locale
+  end
+
   test "sets the current locale to Thread.current" do
     assert_nothing_raised { I18n.locale = 'de' }
     assert_equal :de, I18n.locale


### PR DESCRIPTION
As today, i18n has this behavior:

I18n.locale
I18n.default_locale = :pt
I18n.locale #=> :en

I think that if the locale was not specified, #locale should return the default locale, do you agree?

For example, in a Rails application the default locale is specified the the config/application.rb file. Before loading this code, Rails loads the engines and one of the engines (rails_admin) executes I18n.locale, so the current default locale is cached to @locale and after overriding the default locale, #locale keeps returning the previous default locale, :en in this case.

What do you think?
