### PR TITLE
Gettext::Helpers.N_ method that can be used to help the gettext parser

### DIFF
--- a/lib/i18n/gettext/helpers.rb
+++ b/lib/i18n/gettext/helpers.rb
@@ -7,6 +7,15 @@ module I18n
     #
     #   include I18n::Gettext::Helpers
     module Helpers
+      # Makes dynamic translation messages readable for the gettext parser.
+      # <tt>_(fruit)</tt> cannot be understood by the gettext parser. To help the parser find all your translations,
+      # you can add <tt>fruit = N_("Apple")</tt> which does not translate, but tells the parser: "Apple" needs translation.
+      # * msgid: the message id.
+      # * Returns: msgid.
+      def N_(msgsid)
+        msgsid
+      end
+
       def gettext(msgid, options = {})
         I18n.t(msgid, { :default => msgid, :separator => '|' }.merge(options))
       end

--- a/test/gettext/api_test.rb
+++ b/test/gettext/api_test.rb
@@ -17,6 +17,13 @@ class I18nGettextApiTest < Test::Unit::TestCase
     }, :separator => '|'
   end
 
+  # N_
+  def test_N_returns_original_msg
+    assert_equal 'foo|bar', N_('foo|bar')
+    I18n.locale = :de
+    assert_equal 'Hi Gettext!', N_('Hi Gettext!')
+  end
+
   # gettext
   def test_gettext_uses_msg_as_default
     assert_equal 'Hi Gettext!', _('Hi Gettext!')


### PR DESCRIPTION
This commit make the Gettext::Helpers totally compatible with the Gettext parser of the 'gettext' gem!
