### PR TITLE
Cache#_fetch correctly handles cached 'false'

### DIFF
--- a/lib/i18n/backend/cache.rb
+++ b/lib/i18n/backend/cache.rb
@@ -76,7 +76,8 @@ module I18n
         end
 
         def _fetch(cache_key, &block)
-          result = I18n.cache_store.read(cache_key) and return result
+          result = I18n.cache_store.read(cache_key)
+          return result unless result.nil?
           result = catch(:exception, &block)
           I18n.cache_store.write(cache_key, result) unless result.is_a?(Proc)
           result

--- a/test/backend/cache_test.rb
+++ b/test/backend/cache_test.rb
@@ -36,6 +36,12 @@ class I18nBackendCacheTest < Test::Unit::TestCase
     assert_equal 'Bar', I18n.t(:bar)
   end
 
+  test "translate returns a cached false response" do
+    I18n.backend.expects(:lookup).never
+    I18n.cache_store.expects(:read).returns(false)
+    assert_equal false, I18n.t(:foo)
+  end
+
   test "still raises MissingTranslationData but also caches it" do
     assert_raise(I18n::MissingTranslationData) { I18n.t(:missing, :raise => true) }
     assert_raise(I18n::MissingTranslationData) { I18n.t(:missing, :raise => true) }


### PR DESCRIPTION
ActiveSupport::Cache now caches 'false': https://github.com/rails/rails/commit/cd392fd4da08d1d3b73fa66e945594b89d5f75de

This PR causes Cache#_fetch to return a cached 'false' without performing another lookup.
