### PR TITLE
Fix I18n.interpolate when ActiveSupport::SafeBuffer passed as argument

### DIFF
--- a/lib/i18n/interpolate/ruby.rb
+++ b/lib/i18n/interpolate/ruby.rb
@@ -22,7 +22,7 @@ module I18n
         if match == '%%'
           '%'
         else
-          key = ($1 || $2).to_sym
+          key = ($1 || $2 || match.tr("%{}", "")).to_sym
           value = if values.key?(key)
                     values[key]
                   else

--- a/test/i18n/interpolate_test.rb
+++ b/test/i18n/interpolate_test.rb
@@ -58,6 +58,17 @@ class I18nInterpolateTest < Test::Unit::TestCase
   def test_sprintf_mix_unformatted_and_formatted_named_placeholders
     assert_equal "foo 1.000000", I18n.interpolate("%{name} %<num>f", :name => "foo", :num => 1.0)
   end
+
+  class RailsSafeBuffer < String
+
+    def gsub(*args, &block)
+      to_str.gsub(*args, &block)
+    end
+
+  end
+  test "with String subclass that redefined gsub method" do
+    assert_equal "Hello mars world", I18n.interpolate(RailsSafeBuffer.new("Hello %{planet} world"), :planet => 'mars') 
+  end
 end
 
 class I18nMissingInterpolationCustomHandlerTest < Test::Unit::TestCase


### PR DESCRIPTION
There could be a problem with ActiveSupport::SafeBuffer and I18n interpolate.
I've implemented a part of SafeBuffer that cause the issue in the test case.

``` ruby
I18n.interpolate("%{a}".html_safe, :a => 1)
```

By some reason $1 and $2 is not set appropriately and we have to use gsub match data instead.
