### PR TITLE
I18n::Backend::Memoize is not thread-safe

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    atomic (1.1.14)
     mocha (0.9.9)
       rake
     rake (0.8.7)
     test_declarative (0.0.4)
+    thread_safe (0.1.3)
+      atomic
 
 PLATFORMS
   java
@@ -13,3 +16,4 @@ PLATFORMS
 DEPENDENCIES
   mocha
   test_declarative
+  thread_safe (~> 0.1)

--- a/ci/Gemfile.no-rails
+++ b/ci/Gemfile.no-rails
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'thread_safe', '~> 0.1'
 gem 'mocha'
 gem 'test_declarative'
 

--- a/ci/Gemfile.no-rails.lock
+++ b/ci/Gemfile.no-rails.lock
@@ -1,10 +1,13 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    atomic (1.1.14)
     mocha (0.9.9)
       rake
     rake (0.8.7)
     test_declarative (0.0.4)
+    thread_safe (0.1.3)
+      atomic
 
 PLATFORMS
   ruby
@@ -12,3 +15,4 @@ PLATFORMS
 DEPENDENCIES
   mocha
   test_declarative
+  thread_safe (~> 0.1)

--- a/ci/Gemfile.rails-2.3.x
+++ b/ci/Gemfile.rails-2.3.x
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'thread_safe', '~> 0.1'
 gem 'activesupport', '~> 2.3'
 gem 'sqlite3-ruby'
 gem 'mocha'

--- a/ci/Gemfile.rails-2.3.x.lock
+++ b/ci/Gemfile.rails-2.3.x.lock
@@ -2,6 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     activesupport (2.3.10)
+    atomic (1.1.14)
     ffi (0.6.3)
       rake (>= 0.8.7)
     mocha (0.9.9)
@@ -10,6 +11,8 @@ GEM
     rufus-tokyo (1.0.7)
     sqlite3-ruby (1.3.2)
     test_declarative (0.0.4)
+    thread_safe (0.1.3)
+      atomic
 
 PLATFORMS
   ruby
@@ -21,3 +24,4 @@ DEPENDENCIES
   rufus-tokyo
   sqlite3-ruby
   test_declarative
+  thread_safe (~> 0.1)

--- a/ci/Gemfile.rails-3.x
+++ b/ci/Gemfile.rails-3.x
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'thread_safe', '~> 0.1'
 gem 'activesupport', '~> 3.0.0'
 gem 'sqlite3-ruby'
 gem 'mocha'

--- a/ci/Gemfile.rails-3.x.lock
+++ b/ci/Gemfile.rails-3.x.lock
@@ -2,6 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     activesupport (3.0.3)
+    atomic (1.1.14)
     ffi (0.6.3)
       rake (>= 0.8.7)
     mocha (0.9.9)
@@ -10,6 +11,8 @@ GEM
     rufus-tokyo (1.0.7)
     sqlite3-ruby (1.3.2)
     test_declarative (0.0.4)
+    thread_safe (0.1.3)
+      atomic
 
 PLATFORMS
   ruby
@@ -21,3 +24,4 @@ DEPENDENCIES
   rufus-tokyo
   sqlite3-ruby
   test_declarative
+  thread_safe (~> 0.1)

--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.rubyforge_project = '[none]'
   s.required_rubygems_version = '>= 1.3.5'
 
+  s.add_dependency 'thread_safe', '~> 0.1'
+
   s.add_development_dependency 'activesupport', '>= 3.0.0'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'mocha'

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -1,6 +1,7 @@
 require 'i18n/version'
 require 'i18n/exceptions'
 require 'i18n/interpolate/ruby'
+require 'thread_safe'
 
 module I18n
   autoload :Backend, 'i18n/backend'
@@ -268,6 +269,10 @@ module I18n
       keys
     end
 
+    def new_double_nested_cache # :nodoc:
+      ThreadSafe::Cache.new { |h,k| h[k] = ThreadSafe::Cache.new }
+    end
+
   # making these private until Ruby 1.9.2 can send to protected methods again
   # see http://redmine.ruby-lang.org/repositories/revision/ruby-19?rev=24280
   private
@@ -320,7 +325,7 @@ module I18n
     end
 
     def normalized_key_cache
-      @normalized_key_cache ||= Hash.new { |h,k| h[k] = {} }
+      @normalized_key_cache ||= new_double_nested_cache
     end
 
     # DEPRECATED. Use I18n.normalize_keys instead.

--- a/lib/i18n/backend/flatten.rb
+++ b/lib/i18n/backend/flatten.rb
@@ -43,7 +43,7 @@ module I18n
 
       # Store flattened links.
       def links
-        @links ||= Hash.new { |h,k| h[k] = {} }
+        @links ||= I18n.new_double_nested_cache
       end
 
       # Flatten keys for nested Hashes by chaining up keys:
@@ -99,7 +99,7 @@ module I18n
         end
 
         def find_link(locale, key) #:nodoc:
-          links[locale].each do |from, to|
+          links[locale].each_pair do |from, to|
             return [from, to] if key[0, from.length] == from
           end && nil
         end

--- a/lib/i18n/backend/memoize.rb
+++ b/lib/i18n/backend/memoize.rb
@@ -34,7 +34,7 @@ module I18n
         end
 
         def memoized_lookup
-          @memoized_lookup ||= Hash.new { |h, k| h[k] = {} }
+          @memoized_lookup ||= I18n.new_double_nested_cache
         end
 
         def reset_memoizations!(locale=nil)


### PR DESCRIPTION
`Backend::Memoize` uses a plain `Hash` that is shared between all threads, this is obviously not thread-safe and the module can't be used in truly threaded environments such as JRuby.
