### PR TITLE
Maintain subclasses of Hash when calling Hash#slice

### DIFF
--- a/lib/i18n/core_ext/hash.rb
+++ b/lib/i18n/core_ext/hash.rb
@@ -1,6 +1,6 @@
 class Hash
   def slice(*keep_keys)
-    h = {}
+    h = self.class.new
     keep_keys.each { |key| h[key] = fetch(key) }
     h
   end unless Hash.method_defined?(:slice)

--- a/test/core_ext/hash_test.rb
+++ b/test/core_ext/hash_test.rb
@@ -14,6 +14,12 @@ class I18nCoreExtHashInterpolationTest < Test::Unit::TestCase
     assert_equal expected, hash.slice(:foo)
   end
 
+  test "#slice maintains subclasses of Hash" do
+    klass = Class.new(Hash)
+    hash = klass[:foo, 'bar', :baz, 'bar']
+    assert_instance_of klass,  hash.slice(:foo)
+  end
+
   test "#except" do
     hash = { :foo => 'bar',  :baz => 'bar' }
     expected = { :foo => 'bar' }


### PR DESCRIPTION
This patch corrects i18n's implementation of `Hash#slice` so that it always returns an object of the same class it was originally called on.

In the current implementation, it creates a new hash, copies the selected key/value pairs into it, and returns it. This causes the returned value to be a different class, in the case where the original object was a subclass of Hash. This behavior is problematic when using something like `Hashie` or `HashWithIndifferentAccess`, because translation string interpolation only works for symbols, and keys can be copied into the new hash as strings, depending on the implementation of the subclass.

I discovered this in another library that returns `Hashie::Rash` objects, which work like allow symbol and string key access, but when copied by i18n's `Hash#slice`, lose their ability to look up values by symbol keys.
