### PR TITLE
Fixed tests for stored procs

### DIFF
--- a/lib/i18n/tests/localization/procs.rb
+++ b/lib/i18n/tests/localization/procs.rb
@@ -52,19 +52,19 @@ module I18n
         test "localize Time: given a format that resolves to a Proc it calls the Proc with the object" do
           setup_time_proc_translations
           time = ::Time.utc(2008, 3, 1, 6, 0)
-          assert_equal inspect_args([time, {}]), I18n.l(time, :format => :proc, :locale => :ru)
+          assert_equal I18n::Tests::Localization::Procs.inspect_args([time, {}]), I18n.l(time, :format => :proc, :locale => :ru)
         end
 
         test "localize Time: given a format that resolves to a Proc it calls the Proc with the object and extra options" do
           setup_time_proc_translations
           time = ::Time.utc(2008, 3, 1, 6, 0)
           options = { :foo => 'foo' }
-          assert_equal inspect_args([time, options]), I18n.l(time, options.merge(:format => :proc, :locale => :ru))
+          assert_equal I18n::Tests::Localization::Procs.inspect_args([time, options]), I18n.l(time, options.merge(:format => :proc, :locale => :ru))
         end
 
         protected
 
-          def inspect_args(args)
+          def self.inspect_args(args)
             args = args.map do |arg|
               case arg
               when ::Time, ::DateTime
@@ -85,12 +85,12 @@ module I18n
             I18n.backend.store_translations :ru, {
               :time => {
                 :formats => {
-                  :proc => lambda { |*args| inspect_args(args) }
+                  :proc => lambda { |*args| I18n::Tests::Localization::Procs.inspect_args(args) }
                 }
               },
               :date => {
                 :formats => {
-                  :proc => lambda { |*args| inspect_args(args) }
+                  :proc => lambda { |*args| I18n::Tests::Localization::Procs.inspect_args(args) }
                 },
                 :'day_names' => lambda { |key, options|
                   (options[:format] =~ /^%A/) ?

--- a/lib/i18n/tests/procs.rb
+++ b/lib/i18n/tests/procs.rb
@@ -4,28 +4,29 @@ module I18n
   module Tests
     module Procs
       test "lookup: given a translation is a proc it calls the proc with the key and interpolation values" do
-        I18n.backend.store_translations(:en, :a_lambda => lambda { |*args| filter_args(*args) })
+        I18n.backend.store_translations(:en, :a_lambda => lambda { |*args| I18n::Tests::Procs.filter_args(*args) })
         assert_equal '[:a_lambda, {:foo=>"foo"}]', I18n.t(:a_lambda, :foo => 'foo')
       end
 
       test "defaults: given a default is a Proc it calls it with the key and interpolation values" do
-        proc = lambda { |*args| filter_args(*args) }
+        proc = lambda { |*args| I18n::Tests::Procs.filter_args(*args) }
         assert_equal '[nil, {:foo=>"foo"}]', I18n.t(nil, :default => proc, :foo => 'foo')
       end
 
       test "defaults: given a default is a key that resolves to a Proc it calls it with the key and interpolation values" do
-        I18n.backend.store_translations(:en, :a_lambda => lambda { |*args| filter_args(*args) })
+        the_lambda = lambda { |*args| I18n::Tests::Procs.filter_args(*args) }
+        I18n.backend.store_translations(:en, :a_lambda => the_lambda)
         assert_equal '[:a_lambda, {:foo=>"foo"}]', I18n.t(nil, :default => :a_lambda, :foo => 'foo')
         assert_equal '[:a_lambda, {:foo=>"foo"}]', I18n.t(nil, :default => [nil, :a_lambda], :foo => 'foo')
       end
 
       test "interpolation: given an interpolation value is a lambda it calls it with key and values before interpolating it" do
-        proc = lambda { |*args| filter_args(*args) }
+        proc = lambda { |*args| I18n::Tests::Procs.filter_args(*args) }
         assert_match %r(\[\{:foo=>#<Proc.*>\}\]), I18n.t(nil, :default => '%{foo}', :foo => proc)
       end
 
       test "interpolation: given a key resolves to a Proc that returns a string then interpolation still works" do
-        proc = lambda { |*args| "%{foo}: " + filter_args(*args) }
+        proc = lambda { |*args| "%{foo}: " + I18n::Tests::Procs.filter_args(*args) }
         assert_equal 'foo: [nil, {:foo=>"foo"}]', I18n.t(nil, :default => proc, :foo => 'foo')
       end
 
@@ -37,17 +38,16 @@ module I18n
       end
 
       test "lookup: given the option :resolve => false was passed it does not resolve proc translations" do
-        I18n.backend.store_translations(:en, :a_lambda => lambda { |*args| filter_args(*args) })
+        I18n.backend.store_translations(:en, :a_lambda => lambda { |*args| I18n::Tests::Procs.filter_args(*args) })
         assert_equal Proc, I18n.t(:a_lambda, :resolve => false).class
       end
 
       test "lookup: given the option :resolve => false was passed it does not resolve proc default" do
-        assert_equal Proc, I18n.t(nil, :default => lambda { |*args| filter_args(*args) }, :resolve => false).class
+        assert_equal Proc, I18n.t(nil, :default => lambda { |*args| I18n::Tests::Procs.filter_args(*args) }, :resolve => false).class
       end
 
-      protected
 
-      def filter_args(*args)
+      def self.filter_args(*args)
         args.map {|arg| arg.delete(:fallback) if arg.is_a?(Hash) ; arg }.inspect
       end
     end


### PR DESCRIPTION
On backends that store procs on translations, the context is lost (source_file and line) so they can only access methods fully qualified to be 'findable on evaluation'.

I have updated the i18n-active_record gem and it has now at 100% test success on my branch https://github.com/svenfuchs/i18n-active_record/pull/52

From that test suite, the test defined here are executed and this change is needed to support proc storing.
