### PR TITLE
Don't store translations for locales not set as available with I18n#available_locales=

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -286,6 +286,10 @@ module I18n
       end
     end
 
+    def available_locales_initialized?
+      config.available_locales_initialized?
+    end
+
   # making these private until Ruby 1.9.2 can send to protected methods again
   # see http://redmine.ruby-lang.org/repositories/revision/ruby-19?rev=24280
   private

--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -29,6 +29,11 @@ module I18n
         # translations will be overwritten by new ones only at the deepest
         # level of the hash.
         def store_translations(locale, data, options = {})
+          if I18n.available_locales_initialized? &&
+            I18n.available_locales.include?(locale.to_sym) == false &&
+            I18n.available_locales.include?(locale.to_s) == false
+            return translations
+          end
           locale = locale.to_sym
           translations[locale] ||= {}
           data = data.deep_symbolize_keys

--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -55,6 +55,11 @@ module I18n
       @@available_locales = nil if @@available_locales.empty?
       @@available_locales_set = nil
     end
+    
+    # Returns true if the available_locales have been initialized
+    def available_locales_initialized?
+      ( !!defined?(@@available_locales) && !!@@available_locales )
+    end
 
     # Returns the current default scope separator. Defaults to '.'
     def default_separator

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -69,6 +69,14 @@ class I18nBackendSimpleTest < I18n::TestCase
     assert_equal Hash[:'en', {:foo => {:bar => 'bar', :baz => 'baz'}}], translations
   end
 
+  test "simple store_translations: do not store translations for locales not explicitly marked as available" do
+    I18n.available_locales = [:en, :es]
+    store_translations(:fr, :foo => {:bar => 'barfr', :baz => 'bazfr'})
+    store_translations(:es, :foo => {:bar => 'bares', :baz => 'bazes'})
+    assert_nil translations[:fr]
+    assert_equal Hash[:foo, {:bar => 'bares', :baz => 'bazes'}], translations[:es]
+  end
+
   # reloading translations
 
   test "simple reload_translations: unloads translations" do


### PR DESCRIPTION
If available locales are set explicitly, that means we don't want to work with other locales. This commit puts a check on Simple#store_translation to check if @@available_locales has been set explicitly, and in that case, does not store the data.

Right now, this translations are kept in memory and cached, but never used.

If the value of 'available_locales' is not set explicitly, it works as before, storing translations in any locale.
