### PR TITLE
Allow whitespace in curly bracket interpolations (e.g. "%{ foo }").

### DIFF
--- a/lib/i18n/interpolate/ruby.rb
+++ b/lib/i18n/interpolate/ruby.rb
@@ -4,7 +4,7 @@
 module I18n
   INTERPOLATION_PATTERN = Regexp.union(
     /%%/,
-    /%\{(\w+)\}/,                               # matches placeholders like "%{foo}"
+    /%\{\s*(\w+)\s*\}/,                         # matches placeholders like "%{foo}"
     /%<(\w+)>(.*?\d*\.?\d*[bBdiouxXeEfgGcps])/  # matches placeholders like "%<foo>.d"
   )
 

--- a/test/i18n/interpolate_test.rb
+++ b/test/i18n/interpolate_test.rb
@@ -12,6 +12,10 @@ class I18nInterpolateTest < I18n::TestCase
     assert_equal "Mutoh, Masao", I18n.interpolate("%{last}, %{first}", :first => 'Masao', :last => 'Mutoh' )
   end
 
+  test "String interpolates curly brackets when whitespace is present" do
+    assert_equal "Kaoru Betto", I18n.interpolate("%{ first } %{ last }", :first => 'Kaoru', :last => 'Betto')
+  end
+
   test "String interpolates named placeholders with sprintf syntax" do
     assert_equal "10, 43.4", I18n.interpolate("%<integer>d, %<float>.1f", :integer => 10, :float => 43.4)
   end


### PR DESCRIPTION
For someone who follows the [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide#pad-string-interpolation), the lack of support for whitespace padding inside I18n's interpolation is quite surprising. In fact, I spent quite a bit of time recently hunting for a reason why interpolation wasn't working, when it was just that I was including whitespace inside my brackets. I feel like this violates the principal of least surprise.

This pull request resolves the problem for curly brackets, though I left the %<n>.d interpolation alone. I'd be happy to do same for angle brackets if you would find that prudent.
