### PR TITLE
Allow for the configuration of a cache_key_digest method

### DIFF
--- a/lib/i18n/backend/cache.rb
+++ b/lib/i18n/backend/cache.rb
@@ -13,9 +13,13 @@
 # You can use any cache implementation you want that provides the same API as
 # ActiveSupport::Cache (only the methods #fetch and #write are being used).
 #
-# The cache_key implementation assumes that you only pass values to
-# I18n.translate that return a valid key from #hash (see
-# http://www.ruby-doc.org/core/classes/Object.html#M000337).
+# The cache_key implementation by default assumes you pass values that return
+# a valid key from #hash (see 
+# http://www.ruby-doc.org/core/classes/Object.html#M000337). However, you can 
+# configure your own digest method via which responds to #hexdigest (see 
+# http://ruby-doc.org/stdlib/libdoc/digest/rdoc/index.html):
+#
+#   I18n.cache_key_digest = Digest::MD5.new
 #
 # If you use a lambda as a default value in your translation like this:
 #
@@ -37,6 +41,7 @@ module I18n
   class << self
     @@cache_store = nil
     @@cache_namespace = nil
+    @@cache_key_digest = nil
 
     def cache_store
       @@cache_store
@@ -52,6 +57,14 @@ module I18n
 
     def cache_namespace=(namespace)
       @@cache_namespace = namespace
+    end
+
+    def cache_key_digest
+      @@cache_key_digest
+    end
+
+    def cache_key_digest=(key_digest)
+      @@cache_key_digest = key_digest
     end
 
     def perform_caching?
@@ -84,13 +97,13 @@ module I18n
 
         def cache_key(locale, key, options)
           # This assumes that only simple, native Ruby values are passed to I18n.translate.
-          "i18n/#{I18n.cache_namespace}/#{locale}/#{key.hash}/#{USE_INSPECT_HASH ? options.inspect.hash : options.hash}"
+          "i18n/#{I18n.cache_namespace}/#{locale}/#{digest_item(key)}/#{digest_item(options.inspect)}"
         end
 
       private
-        # In Ruby < 1.9 the following is true: { :foo => 1, :bar => 2 }.hash == { :foo => 2, :bar => 1 }.hash
-        # Therefore we must use the hash of the inspect string instead to avoid cache key colisions.
-        USE_INSPECT_HASH = RUBY_VERSION <= "1.9"
+        def digest_item(key)
+          I18n.cache_key_digest ? I18n.cache_key_digest.hexdigest(key.to_s) : key.hash
+        end
     end
   end
 end

--- a/lib/i18n/backend/cache.rb
+++ b/lib/i18n/backend/cache.rb
@@ -97,10 +97,14 @@ module I18n
 
         def cache_key(locale, key, options)
           # This assumes that only simple, native Ruby values are passed to I18n.translate.
-          "i18n/#{I18n.cache_namespace}/#{locale}/#{digest_item(key)}/#{digest_item(options.inspect)}"
+          "i18n/#{I18n.cache_namespace}/#{locale}/#{digest_item(key)}/#{USE_INSPECT_HASH ? digest_item(options.inspect) : digest_item(options)}"
         end
 
       private
+        # In Ruby < 1.9 the following is true: { :foo => 1, :bar => 2 }.hash == { :foo => 2, :bar => 1 }.hash
+        # Therefore we must use the hash of the inspect string instead to avoid cache key colisions.
+        USE_INSPECT_HASH = RUBY_VERSION <= "1.9"
+
         def digest_item(key)
           I18n.cache_key_digest ? I18n.cache_key_digest.hexdigest(key.to_s) : key.hash
         end

--- a/test/backend/cache_test.rb
+++ b/test/backend/cache_test.rb
@@ -15,6 +15,7 @@ class I18nBackendCacheTest < I18n::TestCase
     I18n.backend = Backend.new
     super
     I18n.cache_store = ActiveSupport::Cache.lookup_store(:memory_store)
+    I18n.cache_key_digest = nil
   end
 
   def teardown
@@ -60,8 +61,17 @@ class I18nBackendCacheTest < I18n::TestCase
 
   test "adds locale and hash of key and hash of options" do
     options = { :bar=>1 }
-    options_hash = I18n::Backend::Cache::USE_INSPECT_HASH ? options.inspect.hash : options.hash
+    options_hash = options.inspect.hash
     assert_equal "i18n//en/#{:foo.hash}/#{options_hash}", I18n.backend.send(:cache_key, :en, :foo, options)
+  end
+
+  test "cache_key uses configured digest method" do
+    md5 = Digest::MD5.new
+    options = { :bar=>1 }
+    options_hash = options.inspect
+    with_cache_key_digest(md5) do
+      assert_equal "i18n//en/#{md5.hexdigest(:foo.to_s)}/#{md5.hexdigest(options_hash)}", I18n.backend.send(:cache_key, :en, :foo, options)
+    end
   end
 
   test "keys should not be equal" do
@@ -80,6 +90,12 @@ class I18nBackendCacheTest < I18n::TestCase
       I18n.cache_namespace = namespace
       yield
       I18n.cache_namespace = nil
+    end
+
+    def with_cache_key_digest(digest)
+      I18n.cache_key_digest = digest
+      yield
+      I18n.cache_key_digest = nil
     end
 end
 

--- a/test/backend/cache_test.rb
+++ b/test/backend/cache_test.rb
@@ -61,7 +61,7 @@ class I18nBackendCacheTest < I18n::TestCase
 
   test "adds locale and hash of key and hash of options" do
     options = { :bar=>1 }
-    options_hash = options.inspect.hash
+    options_hash = RUBY_VERSION <= "1.9" ? options.inspect.hash : options.hash
     assert_equal "i18n//en/#{:foo.hash}/#{options_hash}", I18n.backend.send(:cache_key, :en, :foo, options)
   end
 


### PR DESCRIPTION
This will allow someone to use something other than #hash on an object (which will change per VM startup).
Documented in issues #146 and #52; as well as [here](https://www.ruby-forum.com/topic/560622). Demonstrated here on 2.1.2:

``` ruby
$ irb
~> Console extensions: wirble hirb ap rails2 rails3 pm interactive_editor
>> 'foo'.hash
=> -2698411427522052147
>> exit
$ irb
~> Console extensions: wirble hirb ap rails2 rails3 pm interactive_editor
>> 'foo'.hash
=> 3357245547237632663
```

This is especially handy when using something like Redis to cache values which should persist across server restarts and allow for multiple application instances to talk to the same  Redis server, or multiple applications sharing the same translation store.

Using something like Digest::MD5 takes double the time as Object#hash. However, the digest value remains consistent for the same raw value across multiple VMs.

I've done some benchmarks using different hashing algorithms and have uploaded the results [here](https://gist.github.com/evanmiller67/4658b1b05c805b4c8ed2).

Props to @yellow5 for his help digging through with me!
