### PR TITLE
Teach Hash#slice to only include keys that exist in original

### DIFF
--- a/lib/i18n/core_ext/hash.rb
+++ b/lib/i18n/core_ext/hash.rb
@@ -1,7 +1,7 @@
 class Hash
   def slice(*keep_keys)
     h = {}
-    keep_keys.each { |key| h[key] = fetch(key) }
+    keep_keys.each { |key| h[key] = fetch(key) if has_key?(key) }
     h
   end unless Hash.method_defined?(:slice)
 

--- a/test/core_ext/hash_test.rb
+++ b/test/core_ext/hash_test.rb
@@ -14,6 +14,12 @@ class I18nCoreExtHashInterpolationTest < I18n::TestCase
     assert_equal expected, hash.slice(:foo)
   end
 
+  test "#slice non-existent key" do
+    hash = { :foo => 'bar',  :baz => 'bar' }
+    expected = { :foo => 'bar' }
+    assert_equal expected, hash.slice(:foo, :not_here)
+  end
+
   test "#except" do
     hash = { :foo => 'bar',  :baz => 'bar' }
     expected = { :foo => 'bar' }


### PR DESCRIPTION
Previously this would blow up if you asked for a key that wasn't in the
original hash. This is consistent with Rails' version of Hash#slice.