### PR TITLE
#291 - slice function will not crash if keep_key is not in the hash

### DIFF
--- a/lib/i18n/core_ext/hash.rb
+++ b/lib/i18n/core_ext/hash.rb
@@ -1,7 +1,7 @@
 class Hash
   def slice(*keep_keys)
     h = {}
-    keep_keys.each { |key| h[key] = fetch(key) }
+    keep_keys.each { |key| h[key] = fetch(key) if has_key?(key) }
     h
   end unless Hash.method_defined?(:slice)
 

--- a/test/core_ext/hash_test.rb
+++ b/test/core_ext/hash_test.rb
@@ -14,8 +14,8 @@ class I18nCoreExtHashInterpolationTest < I18n::TestCase
     assert_equal expected, hash.slice(:foo)
 
     hash = { :foo => 'bar', :baz => 'bar' }
-    expected = { :foo => 'bar', :baz => 'bar' }
-    assert_equal expected, hash.slice(:missing_key)
+    expected = { :foo => 'bar' }
+    assert_equal expected, hash.slice(:missing_key, :foo)
   end
 
   test "#except" do

--- a/test/core_ext/hash_test.rb
+++ b/test/core_ext/hash_test.rb
@@ -12,6 +12,10 @@ class I18nCoreExtHashInterpolationTest < I18n::TestCase
     hash = { :foo => 'bar',  :baz => 'bar' }
     expected = { :foo => 'bar' }
     assert_equal expected, hash.slice(:foo)
+
+    hash = { :foo => 'bar', :baz => 'bar')
+    expected = { :foo => 'bar', :baz => 'bar' }
+    assert_equal expected, hash.slice(:missing_key)
   end
 
   test "#except" do

--- a/test/core_ext/hash_test.rb
+++ b/test/core_ext/hash_test.rb
@@ -13,7 +13,7 @@ class I18nCoreExtHashInterpolationTest < I18n::TestCase
     expected = { :foo => 'bar' }
     assert_equal expected, hash.slice(:foo)
 
-    hash = { :foo => 'bar', :baz => 'bar')
+    hash = { :foo => 'bar', :baz => 'bar' }
     expected = { :foo => 'bar', :baz => 'bar' }
     assert_equal expected, hash.slice(:missing_key)
   end


### PR DESCRIPTION
If `slice([:some_key])` is called on a hash that doesn't contain `some_key`, an error will be raised and the application will crash.

This PR allows keep_keys to be specified that are not in the original hash.