### PR TITLE
Don't try to duplicate nil options

### DIFF
--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -43,7 +43,8 @@ module I18n
       attr_reader :locale, :key, :options
 
       def initialize(locale, key, options = nil)
-        @key, @locale, @options = key, locale, options.dup || {}
+        options = options && options.dup || {}
+        @key, @locale, @options = key, locale, options
         options.each { |k, v| self.options[k] = v.inspect if v.is_a?(Proc) }
       end
 

--- a/test/i18n/exceptions_test.rb
+++ b/test/i18n/exceptions_test.rb
@@ -13,6 +13,11 @@ class I18nExceptionsTest < I18n::TestCase
     end
   end
 
+  test "MissingTranslation::Base#initialize can be called without options" do
+    exception = I18n::MissingTranslation.new(:en, 'foo')
+    assert_equal({}, exception.options)
+  end
+
   test "MissingTranslationData exception stores locale, key and options" do
     force_missing_translation_data do |exception|
       assert_equal 'de', exception.locale


### PR DESCRIPTION
In the case when `options` is omitted, calling `.dup` on it results in `TypeError:   can't dup NilClass`.