### PR TITLE
deep interpolation

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -9,7 +9,7 @@ module I18n
   autoload :Locale,  'i18n/locale'
   autoload :Tests,   'i18n/tests'
 
-  RESERVED_KEYS = [:scope, :default, :separator, :resolve, :object, :fallback, :format, :cascade, :throw, :raise]
+  RESERVED_KEYS = [:scope, :default, :separator, :resolve, :object, :fallback, :format, :cascade, :throw, :raise, :deep_interpolation]
   RESERVED_KEYS_PATTERN = /%\{(#{RESERVED_KEYS.join("|")})\}/
 
   extend(Module.new {

--- a/lib/i18n/tests/interpolation.rb
+++ b/lib/i18n/tests/interpolation.rb
@@ -104,6 +104,26 @@ module I18n
         assert_raise(I18n::ReservedInterpolationKey) { interpolate(:default => '%{separator}', :foo => :bar) }
       end
 
+      test "interpolation: deep interpolation for default string" do
+        assert_equal 'Hi %{name}!', interpolate(:default => 'Hi %{name}!', :deep_interpolation => true)
+      end
+
+      test "interpolation: deep interpolation for interpolated string" do
+        assert_equal 'Hi Ann!', interpolate(:default => 'Hi %{name}!', :name => 'Ann', :deep_interpolation => true)
+      end
+
+      test "interpolation: deep interpolation for Hash" do
+        people = { :people => { :ann => 'Ann is %{ann}', :john => 'John is %{john}' } }
+        interpolated_people = { :people => { :ann => 'Ann is good', :john => 'John is big' } }
+        assert_equal interpolated_people, interpolate(:default => people, :ann => 'good', :john => 'big', :deep_interpolation => true)
+      end
+
+      test "interpolation: deep interpolation for Array" do
+        people = { :people => ['Ann is %{ann}', 'John is %{john}'] }
+        interpolated_people = { :people => ['Ann is good', 'John is big'] }
+        assert_equal interpolated_people, interpolate(:default => people, :ann => 'good', :john => 'big', :deep_interpolation => true)
+      end
+
       protected
 
       def capture(stream)


### PR DESCRIPTION
Sometimes I need to get a key with a bunch of inner keys and I can't get them interpolated.

``` yaml
people:
  ann: 'Ann is %{ann}'
  john: 'Ann is %{john}'
```

``` ruby
I18n.t 'people', ann: 'good', john: 'big'
#=> { ann: 'Ann is %{ann}', john: 'John is %{john}' }

# Proposing this approach
I18n.t 'people', ann: 'good', john: 'big', deep_interpolation: true
#=> { ann: 'Ann is good', john: 'John is big' }
```
