### PR TITLE
Fix fallbacks when translating key arrays

### DIFF
--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -38,18 +38,21 @@ module I18n
         return super if options[:fallback]
         default = extract_non_symbol_default!(options) if options[:default]
 
-        options[:fallback] = true
-        I18n.fallbacks[locale].each do |fallback|
-          begin
-            catch(:exception) do
-              result = super(fallback, key, options)
-              return result unless result.nil?
+        begin
+          options[:fallback] = true
+          I18n.fallbacks[locale].each do |fallback|
+            begin
+              catch(:exception) do
+                result = super(fallback, key, options)
+                return result unless result.nil?
+              end
+            rescue I18n::InvalidLocale
+              # we do nothing when the locale is invalid, as this is a fallback anyways.
             end
-          rescue I18n::InvalidLocale
-            # we do nothing when the locale is invalid, as this is a fallback anyways.
           end
+        ensure
+          options.delete(:fallback)
         end
-        options.delete(:fallback)
 
         return super(locale, nil, options.merge(:default => default)) if default
         throw(:exception, I18n::MissingTranslation.new(locale, key, options))

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -141,6 +141,10 @@ class I18nBackendFallbacksWithChainTest < I18n::TestCase
     assert_equal 'FOO', I18n.t(:foo, :locale => :'de-DE')
   end
 
+  test "falls back from de-DE to de when there is no translation for de-DE available when using arrays, too" do
+    assert_equal ['FOO', 'FOO'], I18n.t([:foo, :foo], :locale => :'de-DE')
+  end
+
   test "should not raise error when enforce_available_locales is true, :'pt' is missing and default is a Symbol" do
     I18n.enforce_available_locales = true
     begin


### PR DESCRIPTION
This fixes a problem when translating multiple keys at once. The (temporary) `:fallback` flag was not removed from the `options` parameter after successfully translating the first key. That way it "leaked" into the next iteration, which effectively disabled the fallback mechanism for all following keys.

This should fix #104 and #293.
