### PR TITLE
Ignore metadata for frozen classes.

### DIFF
--- a/lib/i18n/backend/metadata.rb
+++ b/lib/i18n/backend/metadata.rb
@@ -21,11 +21,15 @@ module I18n
         def included(base)
           Object.class_eval do
             def translation_metadata
-              @translation_metadata ||= {}
+              unless self.frozen?
+                @translation_metadata ||= {}
+              else
+                {}
+              end
             end
 
             def translation_metadata=(translation_metadata)
-              @translation_metadata = translation_metadata
+              @translation_metadata = translation_metadata unless self.frozen?
             end
           end unless Object.method_defined?(:translation_metadata)
         end


### PR DESCRIPTION
This makes test suite pass with Ruby 2.2. Basically, it tries to avoid modification of frozen object due to translation metadata.

However, I am not really sure if this is the best approach. May be the translated object should be always just some kind of facade, since for some cases the metadata won't be available. On the other hand, this is not new error, it is just more exposed due to frozen true/false objects in Ruby 2.2
