### PR TITLE
Allow custom interpolation patterns for placeholders

### DIFF
--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -136,5 +136,18 @@ module I18n
     def enforce_available_locales=(enforce_available_locales)
       @@enforce_available_locales = enforce_available_locales
     end
+
+    # Allows clients to provide custom placeholders.
+    #
+    # E.g. using {{}} as a placeholder: "{{hello}}, world!"
+    # I18n.config.interpolation_patterns << /\{\{(\w+)\}\}/
+    def interpolation_patterns
+      @@interpolation_patterns ||= I18n::INTERPOLATION_PATTERNS
+    end
+
+    # Sets interpolation patterns. Expect an array of patterns.
+    def interpolation_patterns=(interpolation_patterns)
+      @@interpolation_patterns = interpolation_patterns
+    end
   end
 end

--- a/test/i18n/interpolate_test.rb
+++ b/test/i18n/interpolate_test.rb
@@ -78,3 +78,20 @@ class I18nMissingInterpolationCustomHandlerTest < I18n::TestCase
       I18n.interpolate("%{first} %{last}", :first => 'Masao')
   end
 end
+
+class I18nCustomInterpolationPatternTest < I18n::TestCase
+  def setup
+    super
+    @old_interpolation_patterns = I18n.config.interpolation_patterns
+    I18n.config.interpolation_patterns << /\{\{(\w+)\}\}/
+  end
+
+  def teardown
+    I18n.config.interpolation_patterns = @old_interpolation_patterns
+    super
+  end
+
+  test "String interpolation can use custom interpolation pattern" do
+    assert_equal "Masao Mutoh", I18n.interpolate("{{first}} {{last}}", :first => 'Masao', :last => 'Mutoh')
+  end
+end


### PR DESCRIPTION
## Pain
In our project we use `%{foo}` placeholders for rails back end translations and `{{foo}}` for ember client. In some cases we need the same translation both at back end and front end which is a pain to support the same translations only because of different interpolation placeholders. 

## Solution
I added an ability to configure custom interpolation patterns in i18n so that different placeholders can be used:

    I18n.config.interpolation_patterns << /\{\{(\w+)\}\}/
