### PR TITLE
Allow live updating to default locale

### DIFF
--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -5,7 +5,7 @@ module I18n
     # The only configuration value that is not global and scoped to thread is :locale.
     # It defaults to the default_locale.
     def locale
-      @locale ||= default_locale
+      @locale || default_locale
     end
 
     # Sets the current locale pseudo-globally, i.e. in the Thread.current hash.


### PR DESCRIPTION
live updates to default_locale were failing because the worker threads stored the old default and referenced the stored value,

This simple fix should allow live updating to the default_locale, so that updates to the default_locale are applied by the active working threads.

See the issue reported [here](https://github.com/svenfuchs/i18n/issues/269).

also see the following test code:

```ruby
require 'i18n'

I18n.available_locales = [:pt, :en]
I18n.enforce_available_locales = true
I18n.default_locale = :en

t1 = Thread.new do
  1.upto(4) do
    # I18n.locale = I18n.default_locale # uncomment to see expected behavior.
    puts I18n.t(:foo)
    sleep 1
  end
end

sleep 0.1

I18n.default_locale = :pt

t1.join

### current output:
# => translation missing: en.foo
# => translation missing: en.foo
# => translation missing: en.foo
# => translation missing: en.foo

### expecting (uncomment the line above to see):
# => translation missing: en.foo
# => translation missing: pt.foo
# => translation missing: pt.foo
# => translation missing: pt.foo
```

P.S.

I tested the conceptual performance difference between ||= and || and it was negligible.

According to the following test on my Macbook, if each request checked the locale 1000 times, than for 1000 requests (total of 1,000,000 calls), a maximum of 0.01 seconds would be added to the process time (and I'm exaggerating):

```ruby
module A
    def self.val
        @a || val2
    end
    def self.val2
        5
    end
end

module B
    def self.val
        @a ||= val2
    end
    def self.val2
        5
    end
end

require 'benchmark'
repeat = 1_000_000
4.times do
    Benchmark.bm do |b|
        b.report("||") {repeat.times { A.val } }
        b.report("||=") {repeat.times { B.val } }
    end; nil
end
```