### PR TITLE
Fix fallback backend so that it works for an array of keys

### DIFF
--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -38,18 +38,16 @@ module I18n
         return super if options[:fallback]
         default = extract_non_symbol_default!(options) if options[:default]
 
-        options[:fallback] = true
         I18n.fallbacks[locale].each do |fallback|
           begin
             catch(:exception) do
-              result = super(fallback, key, options)
+              result = super(fallback, key, options.merge(:fallback => true))
               return result unless result.nil?
             end
           rescue I18n::InvalidLocale
             # we do nothing when the locale is invalid, as this is a fallback anyways.
           end
         end
-        options.delete(:fallback)
 
         return super(locale, nil, options.merge(:default => default)) if default
         throw(:exception, I18n::MissingTranslation.new(locale, key, options))

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -55,6 +55,10 @@ class I18nBackendFallbacksTranslateTest < I18n::TestCase
     assert_equal({}, I18n.t(:missing_bar, :locale => :'de-DE', :default => {}))
   end
 
+  test "returns the translation (fallback as needed) for each key when key is an Array" do
+    assert_equal ['Baz in :de-DE', 'Bar in :de', 'Buz in :en'], I18n.t([:baz, :bar, :buz], :locale => :'de-DE')
+  end
+
   test "returns the :'de-DE' default :baz translation for a missing :'de-DE' when defaults contains Symbol" do
     assert_equal 'Baz in :de-DE', I18n.t(:missing_foo, :locale => :'de-DE', :default => [:baz, "Default Bar"])
   end


### PR DESCRIPTION
When multiple keys are passed to translate() as an array the following code in [i18n.rb](https://github.com/svenfuchs/i18n/blob/master/lib/i18n.rb#L155-L159) will loop through the keys to apply the fallback translation on each one of them. It re-uses the same options while doing so. As a result it only works for the first key because subsequent translation fails due to polluted `options[:fallback]`.

```
        if key.is_a?(Array)
          key.map { |k| backend.translate(locale, k, options) }
        else
          backend.translate(locale, key, options)
        end
```

This PR fixes the issue by creating a new options object when calling super so that original options is not modified and can be re-used.
