### PR TITLE
Excludes "Ruby(1.9 - 2.1) * Rails master" from test cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,13 @@ gemfile:
   - gemfiles/Gemfile.rails-master
 
 matrix:
+  exclude:
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile.rails-master
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile.rails-master
+    - rvm: 2.1
+      gemfile: gemfiles/Gemfile.rails-master
   allow_failures:
     - rvm: 2.2
     - rvm: rbx


### PR DESCRIPTION
Rails 5 requires Ruby greater than 2.2.2, it is better to
exclude Ruby under 2.1 with Rails master tests.
