### PR TITLE
Update base.rb

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -34,7 +34,7 @@ module I18n
             default(locale, key, default, options) : resolve(locale, key, entry, options)
         end
 
-        throw(:exception, I18n::MissingTranslation.new(locale, key, options)) if entry.nil?
+        raise I18n::MissingTranslation.new(locale, key, options) if entry.nil?
         entry = entry.dup if entry.is_a?(String)
 
         entry = pluralize(locale, entry, count) if count


### PR DESCRIPTION
Use `raise` instead of the obfuscating `throw`.

Before :

```
irb(main):002:0> begin
irb(main):003:1*   throw(:exception, Exception.new('test'))
irb(main):004:1> rescue => error
irb(main):005:1>   puts error.inspect
irb(main):006:1> end
#<UncaughtThrowError: uncaught throw :exception>
=> nil
```
(No way to access the exception class and handle the error)

After:

```
irb(main):007:0> begin
irb(main):008:1*   raise Exception.new('test')
irb(main):009:1> rescue => error
irb(main):010:1>   puts error.inspect
irb(main):011:1> end
Exception: test
	from (irb):8
	from /bundle/gems/railties-4.2.5.1/lib/rails/commands/console.rb:110:in `start'
	from /bundle/gems/railties-4.2.5.1/lib/rails/commands/console.rb:9:in `start'
	from /bundle/gems/railties-4.2.5.1/lib/rails/commands/commands_tasks.rb:68:in `console'
	from /bundle/gems/railties-4.2.5.1/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
	from /bundle/gems/railties-4.2.5.1/lib/rails/commands.rb:17:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```
(Here we can `rescue Exception` and handle the error).