### PR TITLE
Remove unnecessary frozen hash duplication in HashTransliterator

### DIFF
--- a/lib/i18n/backend/transliterator.rb
+++ b/lib/i18n/backend/transliterator.rb
@@ -71,7 +71,7 @@ module I18n
 
         def initialize(rule = nil)
           @rule = rule
-          add DEFAULT_APPROXIMATIONS.dup
+          add_default_approximations
           add rule if rule
         end
 
@@ -85,6 +85,12 @@ module I18n
 
         def approximations
           @approximations ||= {}
+        end
+
+        def add_default_approximations
+          DEFAULT_APPROXIMATIONS.each do |key, value|
+            approximations[key] = value
+          end
         end
 
         # Add transliteration rules to the approximations hash.


### PR DESCRIPTION
HashTransliterator's initialize method creates a copy of the frozen hash containing default approximations, adds its key-value pairs to the approximations hash.

To avoid creating this temporary hash that serves no purpose after that, this PR adds a new method that fills the approximations hash directly. In the process, it also skips the unnecessary `to_s` calls on each default keys and values we already know are strings.

I saw in #184 that a `freeze` call was added to the `DEFAULT_APPROXIMATIONS` constant in a previous commit to solve concurrency issues. @stevenweber mentioned that the problem was that the DEFAULT_APPROXIMATIONS had a changing state between threads. The `add_default_approximations` method does not stringify keys nor values - we already know they are strings - so this should not be a problem anymore.