### PR TITLE
Set HashTransliterator default replacement char only once

### DIFF
--- a/lib/i18n/backend/transliterator.rb
+++ b/lib/i18n/backend/transliterator.rb
@@ -75,9 +75,9 @@ module I18n
           add rule if rule
         end
 
-        def transliterate(string, replacement = nil)
+        def transliterate(string, replacement = DEFAULT_REPLACEMENT_CHAR)
           string.gsub(/[^\x00-\x7f]/u) do |char|
-            approximations[char] || replacement || DEFAULT_REPLACEMENT_CHAR
+            approximations[char] || replacement
           end
         end
 


### PR DESCRIPTION
If a string is 1000 characters longs, the previous code would check
1000 times if the `replacement` argument was nil, then fallback to
`DEFAULT_REPLACEMENT_CHAR`

By setting in the method's argument definition the default value
once, we skip this potentiel unnecessary check.

I know this is a very minor performance gain, but every little bit helps, I think.