### PR TITLE
allow disabling fallback explicitly when calling translate

### DIFF
--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -35,11 +35,12 @@ module I18n
       # it's a Symbol. When the default contains a String, Proc or Hash
       # it is evaluated last after all the fallback locales have been tried.
       def translate(locale, key, options = {})
-        return super if options[:fallback]
+        return super unless options.fetch(:fallback, true)
+        return super if (@fallback_locked ||= false)
         default = extract_non_symbol_default!(options) if options[:default]
 
         begin
-          options[:fallback] = true
+          @fallback_locked = true
           I18n.fallbacks[locale].each do |fallback|
             begin
               catch(:exception) do
@@ -51,7 +52,7 @@ module I18n
             end
           end
         ensure
-          options.delete(:fallback)
+          @fallback_locked = false
         end
 
         return super(locale, nil, options.merge(:default => default)) if default

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -68,6 +68,14 @@ class I18nBackendFallbacksTranslateTest < I18n::TestCase
     assert_equal 'Default 6 Bars', I18n.t(:missing_foo, :locale => :'de-DE', :default => [:missing_bar, {:other => "Default %{count} Bars"}, "Default Bar"], :count => 6)
   end
 
+  test "returns the default translation for a missing :de translation even when default is a String when fallback is disabled" do
+    assert_equal 'Default String', I18n.t(:foo, :locale => :de, :default => 'Default String', :fallback => false)
+  end
+
+  test "raises I18n::MissingTranslationData exception when fallback is disabled even when fallback translation exists" do
+    assert_raise(I18n::MissingTranslationData) { I18n.t(:foo, :locale => :de, :fallback => false, :raise => true) }
+  end
+
   test "raises I18n::MissingTranslationData exception when no translation was found" do
     assert_raise(I18n::MissingTranslationData) { I18n.t(:faa, :locale => :en, :raise => true) }
     assert_raise(I18n::MissingTranslationData) { I18n.t(:faa, :locale => :de, :raise => true) }


### PR DESCRIPTION
e.g. by doing `I18n.translate(:key, :fallback => false)`

note that currently, we sort of able to do this by doing `I18n.translate(:key, :fallback => true)`, which are quite a confusing behavior, introduced -- I assumed -- unintentionally because we're [modifying options](https://github.com/svenfuchs/i18n/commit/957145ef85875b913a93502111368b4fc2c67fd5).. so this PR does have backward incompatibility changes, even though it's one that was not officially supported before?

another note is, in the wiki for fallbacks, we have something like:

> You can skip the fallback and return the default by passing in an empty fallback array
> 
> `I18n.translate(:foo, :locale => :de, :default => 'Default Foo', :fallbacks => [])   # => 'Default Foo'`

which does not seems to works.. if what the wiki is saying is the preferred way for supporting disabling fallback, I'm happy to change this PR to do just that, though, I must say that having both `fallback` and `fallbacks` as part of the options will be confusing..