### PR TITLE
Fixes for tests

### DIFF
--- a/lib/i18n/tests/basics.rb
+++ b/lib/i18n/tests/basics.rb
@@ -37,7 +37,8 @@ module I18n
       end
 
       test "available_locales delegates to the backend when not set explicitely" do
-        I18n.backend.expects(:available_locales).twice
+        original_available_locales_value = I18n.backend.available_locales
+        I18n.backend.expects(:available_locales).returns(original_available_locales_value).twice
         assert_equal I18n.backend.available_locales, I18n.available_locales
       end
 

--- a/lib/i18n/tests/basics.rb
+++ b/lib/i18n/tests/basics.rb
@@ -38,7 +38,7 @@ module I18n
 
       test "available_locales delegates to the backend when not set explicitely" do
         I18n.backend.expects(:available_locales).twice
-        assert_equal I18n.available_locales, I18n.available_locales
+        assert_equal I18n.backend.available_locales, I18n.available_locales
       end
 
       test "exists? is implemented by the backend" do

--- a/lib/i18n/tests/defaults.rb
+++ b/lib/i18n/tests/defaults.rb
@@ -29,7 +29,7 @@ module I18n
       end
 
       test "defaults: given nil it returns nil" do
-        assert_equal nil, I18n.t(:does_not_exist, :default => nil)
+        assert_nil I18n.t(:does_not_exist, :default => nil)
       end
 
       test "defaults: given an array of missing keys it raises a MissingTranslationData exception" do

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -270,7 +270,7 @@ class I18nTest < I18n::TestCase
   end
 
   test "localize given nil and default returns default" do
-    assert_equal nil, I18n.l(nil, :default => nil)
+    assert_nil I18n.l(nil, :default => nil)
   end
 
   test "localize given an Object raises an I18n::ArgumentError" do


### PR DESCRIPTION
The original assertion [here](https://github.com/svenfuchs/i18n/compare/master...amatsuda:tests?expand=1#diff-a059d70297e1a18b596187426edea1d1L41) compares `I18n.available_locales` with `I18n.available_locales`, which doesn't actually test anything.
Also, `expects` from mocha changes the return value to `nil`, so it causes this minitest warning https://github.com/seattlerb/minitest/blob/c6ba2afd90473b76d289562edd24f7d7ca8484f9/lib/minitest/assertions.rb

This PR fixes this problem, plus other two `assert_equal nil` warnings.