### PR TITLE
Cleaning up .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ matrix:
     - rvm: ruby-head
       gemfile: gemfiles/Gemfile.rails-4.2.x
   allow_failures:
-    - rvm: 2.2
     - rvm: rbx
     - rvm: jruby
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.1.8
   - 2.2.4
   - 2.3.1
+  - 2.4.0
   - ruby-head
   - rbx
   - jruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,6 @@ matrix:
       gemfile: gemfiles/Gemfile.rails-5.0.x
     - rvm: 2.1.10
       gemfile: gemfiles/Gemfile.rails-5.0.x
-    # activesupport has a dependency on json, which does not build on this version
-    - rvm: ruby-head
-      gemfile: gemfiles/Gemfile.rails-4.1.x
-    # activesupport has a dependency on json, which does not build on this version
-    - rvm: ruby-head
-      gemfile: gemfiles/Gemfile.rails-4.2.x
   allow_failures:
     - rvm: rbx
     - rvm: jruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ before_install:
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.8
-  - 2.2.4
-  - 2.3.1
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
   - 2.4.0
   - ruby-head
   - rbx
@@ -28,13 +28,13 @@ matrix:
       gemfile: gemfiles/Gemfile.rails-master
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.rails-master
-    - rvm: 2.1.8
+    - rvm: 2.1.10
       gemfile: gemfiles/Gemfile.rails-master
     - rvm: 1.9.3
       gemfile: gemfiles/Gemfile.rails-5.0.x
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.rails-5.0.x
-    - rvm: 2.1.8
+    - rvm: 2.1.10
       gemfile: gemfiles/Gemfile.rails-5.0.x
     # activesupport has a dependency on json, which does not build on this version
     - rvm: ruby-head


### PR DESCRIPTION
This PR removes some unneeded lines from `.travis.yml`, and updates tested ruby versions to the newest ones.