### PR TITLE
Docs: Add 0.8.0 to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * `Hash#slice` ignores non existing keys.
 
+# 0.8.0
+
+See https://github.com/svenfuchs/i18n/releases/tag/0.8.0.beta1
+
 # 0.7.0
 
 * Drop support to Ruby 1.8.7 / REE


### PR DESCRIPTION
[ci skip]