### PR TITLE
Fix transliteration to default replacement char

### DIFF
--- a/lib/i18n/backend/transliterator.rb
+++ b/lib/i18n/backend/transliterator.rb
@@ -75,7 +75,8 @@ module I18n
           add rule if rule
         end
 
-        def transliterate(string, replacement = DEFAULT_REPLACEMENT_CHAR)
+        def transliterate(string, replacement = nil)
+          replacement ||= DEFAULT_REPLACEMENT_CHAR
           string.gsub(/[^\x00-\x7f]/u) do |char|
             approximations[char] || replacement
           end

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -351,6 +351,10 @@ class I18nTest < I18n::TestCase
     end
   end
 
+  test "transliterate non-ASCII chars not in map with default replacement char" do
+    assert_equal "???", I18n.transliterate("日本語")
+  end
+
   test "I18n.locale_available? returns true when the passed locale is available" do
     I18n.available_locales = [:en, :de]
     assert_equal true, I18n.locale_available?(:de)


### PR DESCRIPTION
Commit f6a4294c introduced a bug where non-ASCII chars not present in
the transliteration map would be removed from the output, instead of
being replaced by the default replacement char, violating the behaviour
stated in the documentation:

    I18n.transliterate("日本語")
    # => ""         (should be "???")

This fixes the issue while preserving the optimization introduced by
that commit.