### PR TITLE
Initialize global hash during module load

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -323,8 +323,10 @@ module I18n
       end
     end
 
+    @@normalized_key_cache = Concurrent::Hash.new { |h, k| h[k] = Concurrent::Hash.new }
+
     def normalize_key(key, separator)
-      normalized_key_cache[separator][key] ||=
+      @@normalized_key_cache[separator][key] ||=
         case key
         when Array
           key.map { |k| normalize_key(k, separator) }.flatten
@@ -334,10 +336,6 @@ module I18n
           keys.map! { |k| k.to_sym }
           keys
         end
-    end
-
-    def normalized_key_cache
-      @normalized_key_cache ||= Concurrent::Hash.new { |h,k| h[k] = Concurrent::Hash.new }
     end
   end
 


### PR DESCRIPTION
The idiom for lazy initialization with operator `||=` is not thread
safe. Method `I18n#normalized_key_cache` was converted into a class
variable initialized during module load to avoid a race condition.