### PR TITLE
Improve error message for missing pluralization key

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -136,14 +136,14 @@ module I18n
         # - It will pick the :other subkey otherwise.
         # - It will pick the :zero subkey in the special case where count is
         #   equal to 0 and there is a :zero subkey present. This behaviour is
-        #   not stand with regards to the CLDR pluralization rules.
+        #   not standard with regards to the CLDR pluralization rules.
         # Other backends can implement more flexible or complex pluralization rules.
         def pluralize(locale, entry, count)
           return entry unless entry.is_a?(Hash) && count
 
           key = :zero if count == 0 && entry.has_key?(:zero)
           key ||= count == 1 ? :one : :other
-          raise InvalidPluralizationData.new(entry, count) unless entry.has_key?(key)
+          raise InvalidPluralizationData.new(entry, count, key) unless entry.has_key?(key)
           entry[key]
         end
 

--- a/lib/i18n/backend/pluralization.rb
+++ b/lib/i18n/backend/pluralization.rb
@@ -32,7 +32,7 @@ module I18n
         pluralizer = pluralizer(locale)
         if pluralizer.respond_to?(:call)
           key = count == 0 && entry.has_key?(:zero) ? :zero : pluralizer.call(count)
-          raise InvalidPluralizationData.new(entry, count) unless entry.has_key?(key)
+          raise InvalidPluralizationData.new(entry, count, key) unless entry.has_key?(key)
           entry[key]
         else
           super

--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -71,10 +71,10 @@ module I18n
   end
 
   class InvalidPluralizationData < ArgumentError
-    attr_reader :entry, :count
-    def initialize(entry, count)
-      @entry, @count = entry, count
-      super "translation data #{entry.inspect} can not be used with :count => #{count}"
+    attr_reader :entry, :count, :key
+    def initialize(entry, count, key)
+      @entry, @count, @key = entry, count, key
+      super "translation data #{entry.inspect} can not be used with :count => #{count}. key '#{key}' is missing."
     end
   end
 

--- a/test/i18n/exceptions_test.rb
+++ b/test/i18n/exceptions_test.rb
@@ -32,16 +32,19 @@ class I18nExceptionsTest < I18n::TestCase
     end
   end
 
-  test "InvalidPluralizationData stores entry and count" do
+  test "InvalidPluralizationData stores entry, count and key" do
     force_invalid_pluralization_data do |exception|
-      assert_equal [:bar], exception.entry
+      assert_equal({:other => "bar"}, exception.entry)
       assert_equal 1, exception.count
+      assert_equal :one, exception.key
     end
   end
 
-  test "InvalidPluralizationData message contains count and data" do
+  test "InvalidPluralizationData message contains count, data and missing key" do
     force_invalid_pluralization_data do |exception|
-      assert_equal 'translation data [:bar] can not be used with :count => 1', exception.message
+      assert_match '1', exception.message
+      assert_match '{:other=>"bar"}', exception.message
+      assert_match 'one', exception.message
     end
   end
 
@@ -71,7 +74,7 @@ class I18nExceptionsTest < I18n::TestCase
       assert_equal 'reserved key :scope used in "%{scope}"', exception.message
     end
   end
-  
+
   test "MissingTranslationData#new can be initialized with just two arguments" do
     assert I18n::MissingTranslationData.new('en', 'key')
   end
@@ -92,7 +95,7 @@ class I18nExceptionsTest < I18n::TestCase
     end
 
     def force_invalid_pluralization_data
-      store_translations('de', :foo => [:bar])
+      store_translations('de', :foo => { :other => 'bar' })
       I18n.translate(:foo, :count => 1, :locale => :de)
     rescue I18n::ArgumentError => e
       block_given? ? yield(e) : raise(e)


### PR DESCRIPTION
The error message for InvalidPluralizationData should include the missing key that triggered the error. For non-default pluralization rules like the CLDR rules for many languages, the sought-for key will not be obvious from the count.

Also, the force_invalid_pluralization_data method in exceptions_test was not actually raising an exception, so a few assertions that relied on it were not being tested.