### PR TITLE
Fixes #369 thread issue when calling translate with fallbacks

### DIFF
--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -36,11 +36,11 @@ module I18n
       # it is evaluated last after all the fallback locales have been tried.
       def translate(locale, key, options = {})
         return super unless options.fetch(:fallback, true)
-        return super if (@fallback_locked ||= false)
+        return super if options[:fallback_in_progress]
         default = extract_non_symbol_default!(options) if options[:default]
 
         begin
-          @fallback_locked = true
+          options[:fallback_in_progress] = true
           I18n.fallbacks[locale].each do |fallback|
             begin
               catch(:exception) do
@@ -52,7 +52,7 @@ module I18n
             end
           end
         ensure
-          @fallback_locked = false
+          options.delete(:fallback_in_progress)
         end
 
         return super(locale, nil, options.merge(:default => default)) if default

--- a/lib/i18n/tests/localization/procs.rb
+++ b/lib/i18n/tests/localization/procs.rb
@@ -72,7 +72,7 @@ module I18n
               when ::Date
                 arg.strftime('%a, %d %b %Y')
               when Hash
-                arg.delete(:fallback)
+                arg.delete(:fallback_in_progress)
                 arg.inspect
               else
                 arg.inspect

--- a/lib/i18n/tests/procs.rb
+++ b/lib/i18n/tests/procs.rb
@@ -48,7 +48,7 @@ module I18n
 
 
       def self.filter_args(*args)
-        args.map {|arg| arg.delete(:fallback) if arg.is_a?(Hash) ; arg }.inspect
+        args.map {|arg| arg.delete(:fallback_in_progress) if arg.is_a?(Hash) ; arg }.inspect
       end
     end
   end


### PR DESCRIPTION
This pull request is a fix for the thread issues discuss in https://github.com/svenfuchs/i18n/issues/369.

In Version 0.7.0 the [`I18n::Backend::Fallbacks#translate` method](https://github.com/svenfuchs/i18n/blob/v0.7.0/lib/i18n/backend/fallbacks.rb#L37) had an internal option called `fallback`.  This was set to `true` when the fallback logic was in progress and was used as a way to prevent fallbacks from getting stuck in an infinite loop:

```ruby
def translate(locale, key, options = {})
  return super if options[:fallback]
  ...
  options[:fallback] = true
  I18n.fallbacks[locale].each do |fallback|
    ...
  end
  options.delete(:fallback)
```

Although `fallback` was an internal option, [this wiki](https://github.com/svenfuchs/i18n/wiki/Fallbacks) made reference to a `fallbacks` flag that could be used to disable fallbacks.

Unfortunately the `fallbacks` flag didn't do anything so [pull request #354](https://github.com/svenfuchs/i18n/pull/354) made a change to allow for passing `fallback: false` as a way to disable the fallback logic.  When that was done [this commit](https://github.com/svenfuchs/i18n/commit/9481e94d243837f8f2f385f0f95368bb601ab939#diff-076afcec0ede6a22e38cbb5510551925) added an instance variable called `@fallback_locked` which breaks thread-safety:

```ruby
def translate(locale, key, options = {})
  return super unless options.fetch(:fallback, true)

  # Depending on the timing, a given thread can incorrectly short-circuit out of the 
  # fallback flow on the next line if @fallback_locked has been set to true but another 
  # thread
  return super if (@fallback_locked ||= false)  # <---
  ...

  begin
    @fallback_locked = true
     I18n.fallbacks[locale].each do |fallback|
  ...

  ensure
    @fallback_locked = false
```

This pull request will remove the instance variable and revert back to the local `options` hash, using a new internal option called `:fallback_in_progress` to control the fallback looping structure in a way that is thread-safe.