### PR TITLE
Introduce middleware that resets current local thread's config after each request

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -8,6 +8,7 @@ module I18n
   autoload :Gettext, 'i18n/gettext'
   autoload :Locale,  'i18n/locale'
   autoload :Tests,   'i18n/tests'
+  autoload :Middleware,   'i18n/middleware'
 
   RESERVED_KEYS = [:scope, :default, :separator, :resolve, :object, :fallback, :fallback_in_progress, :format, :cascade, :throw, :raise, :deep_interpolation]
   RESERVED_KEYS_PATTERN = /%\{(#{RESERVED_KEYS.join("|")})\}/

--- a/lib/i18n/middleware.rb
+++ b/lib/i18n/middleware.rb
@@ -1,0 +1,15 @@
+module I18n
+  class Middleware
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @app.call(env)
+    ensure
+      Thread.current[:i18n_config] = I18n::Config.new
+    end
+
+  end
+end

--- a/test/i18n/middleware_test.rb
+++ b/test/i18n/middleware_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class I18nMiddlewareTest < I18n::TestCase
+  def setup
+    super
+    I18n.default_locale = :fr
+    @app = DummyRackApp.new
+    @middleware = I18n::Middleware.new(@app)
+  end
+
+  test "middleware initializes new config object after request" do
+    old_i18n_config_object_id = Thread.current[:i18n_config].object_id
+    @middleware.call({})
+
+    updated_i18n_config_object_id = Thread.current[:i18n_config].object_id
+    assert_not_equal updated_i18n_config_object_id, old_i18n_config_object_id
+  end
+
+  test "succesfully resets i18n locale to default locale by defining new config" do
+    @middleware.call({})
+
+    assert_equal :fr, I18n.locale
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,3 +53,9 @@ class I18n::TestCase < TEST_CASE
     File.dirname(__FILE__) + '/test_data/locales'
   end
 end
+
+class DummyRackApp
+  def call(env)
+    I18n.locale = :es
+  end
+end


### PR DESCRIPTION
This is a proposal PR.

Rack based apps that work in a multithreaded environment can plugin this
middleware to make sure a context of `locale` is only persisted
in the lifecycle of the request and aren't leaked between requests unintentionally.
Which is common in thread pool like environments.

This is especially helpful if a server/environment isn't cleaning thread local
storage after/before request.

Issue: https://github.com/svenfuchs/i18n/issues/381

---

Update: If this PR is merged, users will need to explicitly require the new middleware

Example:

**config/application.rb**

```ruby
config.middleware.use ::I18n::Middleware
``` 