### PR TITLE
add rails-5.1 to travis, update ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.10
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
   - ruby-head
   - rbx
   - jruby
@@ -19,6 +19,7 @@ gemfile:
   - gemfiles/Gemfile.rails-4.1.x
   - gemfiles/Gemfile.rails-4.2.x
   - gemfiles/Gemfile.rails-5.0.x
+  - gemfiles/Gemfile.rails-5.1.x
   - gemfiles/Gemfile.rails-master
 
 matrix:
@@ -36,6 +37,12 @@ matrix:
       gemfile: gemfiles/Gemfile.rails-5.0.x
     - rvm: 2.1.10
       gemfile: gemfiles/Gemfile.rails-5.0.x
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile.rails-5.1.x
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile.rails-5.1.x
+    - rvm: 2.1.10
+      gemfile: gemfiles/Gemfile.rails-5.1.x
   allow_failures:
     - rvm: rbx
     - rvm: jruby

--- a/gemfiles/Gemfile.rails-5.1.x
+++ b/gemfiles/Gemfile.rails-5.1.x
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec :path => '..'
+
+gem 'activesupport', '~> 5.1.0'
+gem 'mocha'
+gem 'test_declarative'
+gem 'rake'
+gem 'minitest'


### PR DESCRIPTION
This adds a rails-5.1 build to the travis CI build matrix, also bumps ruby ruby versions to latest.