### PR TITLE
Fix travis: Concurrent.map does not expose default_proc

### DIFF
--- a/test/backend/memoize_test.rb
+++ b/test/backend/memoize_test.rb
@@ -60,9 +60,6 @@ class I18nBackendMemoizeTest < I18nBackendSimpleTest
     backend = backend_impl.new
 
     memoized_lookup = backend.send(:memoized_lookup)
-    # make the 'default_proc' execution artificially slower to help reproduce :
-    default_proc = memoized_lookup.default_proc
-    memoized_lookup.default_proc = Proc.new { |h, k| sleep 0.1; default_proc.call(h, k) }
 
     assert_equal "[:foo, :scoped, :sample]", backend.translate('foo', scope = [:scoped, :sample])
 


### PR DESCRIPTION
bf58182cc350a697b3eed67d8d1c41e32b8d27b2 changed underlying implementation from Hash to Concurrent::Map which removes the ability to test this way.