### PR TITLE
Keep the translation missing message when default is not nil

### DIFF
--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -37,8 +37,7 @@ module I18n
       def translate(locale, key, options = {})
         return super unless options.fetch(:fallback, true)
         return super if options[:fallback_in_progress]
-        original_default = options[:default]
-        extract_non_symbol_default!(options)
+        default = extract_non_symbol_default!(options) if options[:default]
 
         begin
           options[:fallback_in_progress] = true
@@ -56,7 +55,9 @@ module I18n
           options.delete(:fallback_in_progress)
         end
 
-        return super(locale, nil, options.merge(:default => original_default)) if options.key?(:default)
+        return if options.key?(:default) && options[:default].nil?
+
+        return super(locale, nil, options.merge(:default => default)) if default
         throw(:exception, I18n::MissingTranslation.new(locale, key, options))
       end
 

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -64,6 +64,10 @@ class I18nBackendFallbacksTranslateTest < I18n::TestCase
     assert_nil I18n.t(:missing_bar, :locale => :'de-DE', :default => nil)
   end
 
+  test "returns the translation missing message if the default is also missing" do
+    assert_equal 'translation missing: de-DE.missing_bar', I18n.t(:missing_bar, :locale => :'de-DE', :default => [:missing_baz])
+  end
+
   test "returns the :'de-DE' default :baz translation for a missing :'de-DE' when defaults contains Symbol" do
     assert_equal 'Baz in :de-DE', I18n.t(:missing_foo, :locale => :'de-DE', :default => [:baz, "Default Bar"])
   end


### PR DESCRIPTION
When either the key and the all the defaults have missing translation we should be showing the original key in the translation missing message.

Before this commit we were showing a translation missing error in the "no key" key.

This commit fixes a regression introduced in #387.