### PR TITLE
Fix Hash#slice behavior not to return a subclass instance

### DIFF
--- a/lib/i18n/core_ext/hash.rb
+++ b/lib/i18n/core_ext/hash.rb
@@ -1,6 +1,6 @@
 class Hash
   def slice(*keep_keys)
-    h = self.class.new
+    h = {}
     keep_keys.each { |key| h[key] = fetch(key) if has_key?(key) }
     h
   end unless Hash.method_defined?(:slice)
@@ -21,7 +21,7 @@ class Hash
   MERGER = proc do |key, v1, v2|
     Hash === v1 && Hash === v2 ? v1.merge(v2, &MERGER) : v2
   end
-
+  
   def deep_merge!(data)
     merge!(data, &MERGER)
   end unless Hash.method_defined?(:deep_merge!)

--- a/test/core_ext/hash_test.rb
+++ b/test/core_ext/hash_test.rb
@@ -20,12 +20,6 @@ class I18nCoreExtHashInterpolationTest < I18n::TestCase
     assert_equal expected, hash.slice(:foo, :not_here)
   end
 
-  test "#slice maintains subclasses of Hash" do
-    klass = Class.new(Hash)
-    hash = klass[:foo, 'bar', :baz, 'bar']
-    assert_instance_of klass,  hash.slice(:foo)
-  end
-
   test "#except" do
     hash = { :foo => 'bar',  :baz => 'bar' }
     expected = { :foo => 'bar' }


### PR DESCRIPTION
`Hash#slice` has been introduced to Ruby core Hash class in 2.5. https://github.com/ruby/ruby/commit/6c50bdda

The Ruby core version of `Class(Hash)#slice` returns a new instance of Hash, not an instance of the subclass, respecting consistency with other existing Hash methods, e. g.

```
Class.new(Hash)[:a, 1, :b, 2].select { true }.class
#=> Hash

Class.new(Hash)[:a, 1, :b, 2].reject { false }.class
#=> Hash
```

This PR fixes the I18n original `Hash#slice` implementation to behave in the same way with that of Ruby 2.5+ simply by reverting 6f291c427bd2df08037fbc500c529fa71b167f97.

I do understand @jimmycuadra's use case described in #250, but in such case, please consider overriding `slice` inside that particular Hash subclass, just as we're doing in [Active Support's hash_with_indifferent_access.rb](https://github.com/rails/rails/blob/c6115fea425ca0b6ce85dcab15be33166ad8ae9f/activesupport/lib/active_support/hash_with_indifferent_access.rb#L314-L317).