### PR TITLE
Fix anonymous objects

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'concurrent/map'
 
 require 'i18n/version'

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -16,7 +16,7 @@ module I18n
 
   RESERVED_KEYS = [:scope, :default, :separator, :resolve, :object, :fallback, :fallback_in_progress, :format, :cascade, :throw, :raise, :deep_interpolation]
   RESERVED_KEYS_PATTERN = /%\{(#{RESERVED_KEYS.join("|")})\}/
-
+  EMPTY_HASH = {}.freeze
 
   def self.new_double_nested_cache # :nodoc:
     Concurrent::Map.new { |h,k| h[k] = Concurrent::Map.new }
@@ -177,7 +177,7 @@ module I18n
 
     # Wrapper for <tt>translate</tt> that adds <tt>:raise => true</tt>. With
     # this option, if no translation is found, it will raise <tt>I18n::MissingTranslationData</tt>
-    def translate!(key, options={})
+    def translate!(key, options = EMPTY_HASH)
       translate(key, options.merge(:raise => true))
     end
     alias :t! :translate!

--- a/lib/i18n/backend.rb
+++ b/lib/i18n/backend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module I18n
   module Backend
     autoload :Base,                  'i18n/backend/base'

--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 require 'i18n/core_ext/hash'
 require 'i18n/core_ext/kernel/suppress_warnings'

--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -19,11 +19,11 @@ module I18n
 
       # This method receives a locale, a data hash and options for storing translations.
       # Should be implemented
-      def store_translations(locale, data, options = {})
+      def store_translations(locale, data, options = EMPTY_HASH)
         raise NotImplementedError
       end
 
-      def translate(locale, key, options = {})
+      def translate(locale, key, options = EMPTY_HASH)
         raise I18n::ArgumentError if (key.is_a?(String) || key.is_a?(Symbol)) && key.empty?
         raise InvalidLocale.new(locale) unless locale
         return nil if key.nil? && !options.key?(:default)
@@ -70,7 +70,7 @@ module I18n
       # Acts the same as +strftime+, but uses a localized version of the
       # format string. Takes a key from the date/time formats translations as
       # a format argument (<em>e.g.</em>, <tt>:short</tt> in <tt>:'date.formats'</tt>).
-      def localize(locale, object, format = :default, options = {})
+      def localize(locale, object, format = :default, options = EMPTY_HASH)
         if object.nil? && options.include?(:default)
           return options[:default]
         end
@@ -99,7 +99,7 @@ module I18n
       protected
 
         # The method which actually looks up for the translation in the store.
-        def lookup(locale, key, scope = [], options = {})
+        def lookup(locale, key, scope = [], options = EMPTY_HASH)
           raise NotImplementedError
         end
 
@@ -111,7 +111,7 @@ module I18n
         # If given subject is an Array, it walks the array and returns the
         # first translation that can be resolved. Otherwise it tries to resolve
         # the translation directly.
-        def default(locale, object, subject, options = {})
+        def default(locale, object, subject, options = EMPTY_HASH)
           options = options.dup.reject { |key, value| key == :default }
           case subject
           when Array
@@ -128,7 +128,7 @@ module I18n
         # If the given subject is a Symbol, it will be translated with the
         # given options. If it is a Proc then it will be evaluated. All other
         # subjects will be returned directly.
-        def resolve(locale, object, subject, options = {})
+        def resolve(locale, object, subject, options = EMPTY_HASH)
           return subject if options[:resolve] == false
           result = catch(:exception) do
             case subject
@@ -170,7 +170,7 @@ module I18n
         #   each element of the array is recursively interpolated (until it finds a string)
         #   method interpolates ["yes, %{user}", ["maybe no, %{user}, "no, %{user}"]], :user => "bartuz"
         #   # => "["yes, bartuz",["maybe no, bartuz", "no, bartuz"]]"
-        def interpolate(locale, subject, values = {})
+        def interpolate(locale, subject, values = EMPTY_HASH)
           return subject if values.empty?
 
           case subject
@@ -186,7 +186,7 @@ module I18n
         #   deep_interpolate { people: { ann: "Ann is %{ann}", john: "John is %{john}" } },
         #                    ann: 'good', john: 'big'
         #   #=> { people: { ann: "Ann is good", john: "John is big" } }
-        def deep_interpolate(locale, data, values = {})
+        def deep_interpolate(locale, data, values = EMPTY_HASH)
           return data if values.empty?
 
           case data

--- a/lib/i18n/backend/cache.rb
+++ b/lib/i18n/backend/cache.rb
@@ -77,7 +77,7 @@ module I18n
   module Backend
     # TODO Should the cache be cleared if new translations are stored?
     module Cache
-      def translate(locale, key, options = {})
+      def translate(locale, key, options = EMPTY_HASH)
         I18n.perform_caching? ? fetch(cache_key(locale, key, options)) { super } : super
       end
 

--- a/lib/i18n/backend/cache.rb
+++ b/lib/i18n/backend/cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This module allows you to easily cache all responses from the backend - thus
 # speeding up the I18n aspects of your application quite a bit.
 #
@@ -14,9 +16,9 @@
 # ActiveSupport::Cache (only the methods #fetch and #write are being used).
 #
 # The cache_key implementation by default assumes you pass values that return
-# a valid key from #hash (see 
-# http://www.ruby-doc.org/core/classes/Object.html#M000337). However, you can 
-# configure your own digest method via which responds to #hexdigest (see 
+# a valid key from #hash (see
+# http://www.ruby-doc.org/core/classes/Object.html#M000337). However, you can
+# configure your own digest method via which responds to #hexdigest (see
 # http://ruby-doc.org/stdlib/libdoc/digest/rdoc/index.html):
 #
 #   I18n.cache_key_digest = Digest::MD5.new

--- a/lib/i18n/backend/cascade.rb
+++ b/lib/i18n/backend/cascade.rb
@@ -33,7 +33,7 @@
 module I18n
   module Backend
     module Cascade
-      def lookup(locale, key, scope = [], options = {})
+      def lookup(locale, key, scope = [], options = EMPTY_HASH)
         return super unless cascade = options[:cascade]
 
         cascade   = { :step => 1 } unless cascade.is_a?(Hash)

--- a/lib/i18n/backend/cascade.rb
+++ b/lib/i18n/backend/cascade.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The Cascade module adds the ability to do cascading lookups to backends that
 # are compatible to the Simple backend.
 #

--- a/lib/i18n/backend/chain.rb
+++ b/lib/i18n/backend/chain.rb
@@ -30,7 +30,7 @@ module I18n
           backends.each { |backend| backend.reload! }
         end
 
-        def store_translations(locale, data, options = {})
+        def store_translations(locale, data, options = EMPTY_HASH)
           backends.first.store_translations(locale, data, options)
         end
 
@@ -38,7 +38,7 @@ module I18n
           backends.map { |backend| backend.available_locales }.flatten.uniq
         end
 
-        def translate(locale, key, default_options = {})
+        def translate(locale, key, default_options = EMPTY_HASH)
           namespace = nil
           options = default_options.except(:default)
 
@@ -64,7 +64,7 @@ module I18n
           end
         end
 
-        def localize(locale, object, format = :default, options = {})
+        def localize(locale, object, format = :default, options = EMPTY_HASH)
           backends.each do |backend|
             catch(:exception) do
               result = backend.localize(locale, object, format, options) and return result

--- a/lib/i18n/backend/chain.rb
+++ b/lib/i18n/backend/chain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module I18n
   module Backend
     # Backend that chains multiple other backends and checks each of them when

--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # I18n locale fallbacks are useful when you want your application to use
 # translations from other locales when translations for the current locale are
 # missing. E.g. you might want to use :en translations when translations in

--- a/lib/i18n/backend/fallbacks.rb
+++ b/lib/i18n/backend/fallbacks.rb
@@ -36,25 +36,21 @@ module I18n
       # The default option takes precedence over fallback locales only when
       # it's a Symbol. When the default contains a String, Proc or Hash
       # it is evaluated last after all the fallback locales have been tried.
-      def translate(locale, key, options = {})
+      def translate(locale, key, options = EMPTY_HASH)
         return super unless options.fetch(:fallback, true)
         return super if options[:fallback_in_progress]
         default = extract_non_symbol_default!(options) if options[:default]
 
-        begin
-          options[:fallback_in_progress] = true
-          I18n.fallbacks[locale].each do |fallback|
-            begin
-              catch(:exception) do
-                result = super(fallback, key, options)
-                return result unless result.nil?
-              end
-            rescue I18n::InvalidLocale
-              # we do nothing when the locale is invalid, as this is a fallback anyways.
+        fallback_options = options.merge(:fallback_in_progress => true)
+        I18n.fallbacks[locale].each do |fallback|
+          begin
+            catch(:exception) do
+              result = super(fallback, key, fallback_options)
+              return result unless result.nil?
             end
+          rescue I18n::InvalidLocale
+            # we do nothing when the locale is invalid, as this is a fallback anyways.
           end
-        ensure
-          options.delete(:fallback_in_progress)
         end
 
         return if options.key?(:default) && options[:default].nil?

--- a/lib/i18n/backend/flatten.rb
+++ b/lib/i18n/backend/flatten.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module I18n
   module Backend
     # This module contains several helpers to assist flattening translations.

--- a/lib/i18n/backend/gettext.rb
+++ b/lib/i18n/backend/gettext.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'i18n/gettext'
 require 'i18n/gettext/po_parser'
 

--- a/lib/i18n/backend/interpolation_compiler.rb
+++ b/lib/i18n/backend/interpolation_compiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The InterpolationCompiler module contains optimizations that can tremendously
 # speed up the interpolation process on the Simple backend.
 #

--- a/lib/i18n/backend/interpolation_compiler.rb
+++ b/lib/i18n/backend/interpolation_compiler.rb
@@ -106,7 +106,7 @@ module I18n
         end
       end
 
-      def store_translations(locale, data, options = {})
+      def store_translations(locale, data, options = EMPTY_HASH)
         compile_all_strings_in(data)
         super
       end

--- a/lib/i18n/backend/key_value.rb
+++ b/lib/i18n/backend/key_value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'i18n/backend/base'
 
 module I18n

--- a/lib/i18n/backend/key_value.rb
+++ b/lib/i18n/backend/key_value.rb
@@ -76,7 +76,7 @@ module I18n
           @store, @subtrees = store, subtrees
         end
 
-        def store_translations(locale, data, options = {})
+        def store_translations(locale, data, options = EMPTY_HASH)
           escape = options.fetch(:escape, true)
           flatten_translations(locale, data, escape, @subtrees).each do |key, value|
             key = "#{locale}.#{key}"
@@ -109,7 +109,7 @@ module I18n
           @subtrees
         end
 
-        def lookup(locale, key, scope = [], options = {})
+        def lookup(locale, key, scope = [], options = EMPTY_HASH)
           key   = normalize_flat_keys(locale, key, scope, options[:separator])
           value = @store["#{locale}.#{key}"]
           value = JSON.decode(value) if value

--- a/lib/i18n/backend/memoize.rb
+++ b/lib/i18n/backend/memoize.rb
@@ -16,7 +16,7 @@ module I18n
         @memoized_locales ||= super
       end
 
-      def store_translations(locale, data, options = {})
+      def store_translations(locale, data, options = EMPTY_HASH)
         reset_memoizations!(locale)
         super
       end
@@ -28,7 +28,7 @@ module I18n
 
       protected
 
-        def lookup(locale, key, scope = nil, options = {})
+        def lookup(locale, key, scope = nil, options = EMPTY_HASH)
           flat_key  = I18n::Backend::Flatten.normalize_flat_keys(locale,
             key, scope, options[:separator]).to_sym
           flat_hash = memoized_lookup[locale.to_sym]

--- a/lib/i18n/backend/memoize.rb
+++ b/lib/i18n/backend/memoize.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Memoize module simply memoizes the values returned by lookup using
 # a flat hash and can tremendously speed up the lookup process in a backend.
 #

--- a/lib/i18n/backend/metadata.rb
+++ b/lib/i18n/backend/metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # I18n translation metadata is useful when you want to access information
 # about how a translation was looked up, pluralized or interpolated in
 # your application.

--- a/lib/i18n/backend/metadata.rb
+++ b/lib/i18n/backend/metadata.rb
@@ -37,7 +37,7 @@ module I18n
         end
       end
 
-      def translate(locale, key, options = {})
+      def translate(locale, key, options = EMPTY_HASH)
         metadata = {
           :locale    => locale,
           :key       => key,
@@ -49,7 +49,7 @@ module I18n
         with_metadata(metadata) { super }
       end
 
-      def interpolate(locale, entry, values = {})
+      def interpolate(locale, entry, values = EMPTY_HASH)
         metadata = entry.translation_metadata.merge(:original => entry)
         with_metadata(metadata) { super }
       end

--- a/lib/i18n/backend/pluralization.rb
+++ b/lib/i18n/backend/pluralization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # I18n Pluralization are useful when you want your application to
 # customize pluralization rules.
 #

--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module I18n
   module Backend
     # A simple backend that reads translations from YAML files and stores them in

--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -30,7 +30,7 @@ module I18n
         # This uses a deep merge for the translations hash, so existing
         # translations will be overwritten by new ones only at the deepest
         # level of the hash.
-        def store_translations(locale, data, options = {})
+        def store_translations(locale, data, options = EMPTY_HASH)
           if I18n.enforce_available_locales &&
             I18n.available_locales_initialized? &&
             !I18n.available_locales.include?(locale.to_sym) &&
@@ -75,7 +75,7 @@ module I18n
         # nested translations hash. Splits keys or scopes containing dots
         # into multiple keys, i.e. <tt>currency.format</tt> is regarded the same as
         # <tt>%w(currency format)</tt>.
-        def lookup(locale, key, scope = [], options = {})
+        def lookup(locale, key, scope = [], options = EMPTY_HASH)
           init_translations unless initialized?
           keys = I18n.normalize_keys(locale, key, scope, options[:separator])
 

--- a/lib/i18n/backend/transliterator.rb
+++ b/lib/i18n/backend/transliterator.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+# frozen_string_literal: true
+
 module I18n
   module Backend
     module Transliterator

--- a/lib/i18n/config.rb
+++ b/lib/i18n/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module I18n
@@ -57,7 +59,7 @@ module I18n
       @@available_locales = nil if @@available_locales.empty?
       @@available_locales_set = nil
     end
-    
+
     # Returns true if the available_locales have been initialized
     def available_locales_initialized?
       ( !!defined?(@@available_locales) && !!@@available_locales )

--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 
 module I18n

--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -44,7 +44,7 @@ module I18n
     module Base
       attr_reader :locale, :key, :options
 
-      def initialize(locale, key, options = {})
+      def initialize(locale, key, options = EMPTY_HASH)
         @key, @locale, @options = key, locale, options.dup
         options.each { |k, v| self.options[k] = v.inspect if v.is_a?(Proc) }
       end

--- a/lib/i18n/gettext.rb
+++ b/lib/i18n/gettext.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module I18n
   module Gettext
     PLURAL_SEPARATOR  = "\001"

--- a/lib/i18n/gettext/helpers.rb
+++ b/lib/i18n/gettext/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'i18n/gettext'
 
 module I18n

--- a/lib/i18n/gettext/helpers.rb
+++ b/lib/i18n/gettext/helpers.rb
@@ -18,7 +18,7 @@ module I18n
         msgsid
       end
 
-      def gettext(msgid, options = {})
+      def gettext(msgid, options = EMPTY_HASH)
         I18n.t(msgid, { :default => msgid, :separator => '|' }.merge(options))
       end
       alias _ gettext

--- a/lib/i18n/gettext/po_parser.rb
+++ b/lib/i18n/gettext/po_parser.rb
@@ -28,7 +28,7 @@ module_eval <<'..end src/poparser.ry modeval..id7a99570e05', 'src/poparser.ry', 
     ret.gsub!(/\\"/, "\"")
     ret
   end
-  
+
   def parse(str, data, ignore_fuzzy = true)
     @comments = []
     @data = data
@@ -64,7 +64,7 @@ module_eval <<'..end src/poparser.ry modeval..id7a99570e05', 'src/poparser.ry', 
 	str = $'
       when /\A\#(.*)/
 	@q.push [:COMMENT, $&]
-	str = $'      
+	str = $'
       when /\A\"(.*)\"/
 	@q.push [:STRING, $1]
 	str = $'
@@ -73,7 +73,7 @@ module_eval <<'..end src/poparser.ry modeval..id7a99570e05', 'src/poparser.ry', 
 	#@q.push [:STRING, c]
 	str = str[1..-1]
       end
-    end 
+    end
     @q.push [false, '$end']
     if $DEBUG
       @q.each do |a,b|
@@ -88,7 +88,7 @@ module_eval <<'..end src/poparser.ry modeval..id7a99570e05', 'src/poparser.ry', 
     end
     @data
   end
-  
+
   def next_token
     @q.shift
   end
@@ -101,11 +101,11 @@ module_eval <<'..end src/poparser.ry modeval..id7a99570e05', 'src/poparser.ry', 
     @comments.clear
     @msgctxt = ""
   end
-      
+
   def on_comment(comment)
     @fuzzy = true if (/fuzzy/ =~ comment)
     @comments << comment
-  end 
+  end
 
 
 ..end src/poparser.ry modeval..id7a99570e05
@@ -245,7 +245,7 @@ module_eval <<'.,.,', 'src/poparser.ry', 25
 
 module_eval <<'.,.,', 'src/poparser.ry', 48
   def _reduce_8( val, _values, result )
-    if @fuzzy and $ignore_fuzzy 
+    if @fuzzy and $ignore_fuzzy
       if val[1] != ""
         $stderr.print _("Warning: fuzzy message was ignored.\n")
         $stderr.print "         msgid '#{val[1]}'\n"

--- a/lib/i18n/locale.rb
+++ b/lib/i18n/locale.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module I18n
   module Locale
   autoload :Fallbacks, 'i18n/locale/fallbacks'

--- a/lib/i18n/middleware.rb
+++ b/lib/i18n/middleware.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module I18n
   class Middleware
 

--- a/lib/i18n/tests.rb
+++ b/lib/i18n/tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module I18n
   module Tests
     autoload :Basics,        'i18n/tests/basics'

--- a/lib/i18n/version.rb
+++ b/lib/i18n/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module I18n
   VERSION = "1.0.0"
 end


### PR DESCRIPTION
Explanation. Trying to remove creation of anonymous objects


```ruby
def test()
  "a" == "b"
end
GC.start
stat1 = GC.stat
1000_000.times do
  test
end
stat2 = GC.stat
p stat2[:count] - stat1[:count] # number of GC sweeps (minor + major)
```

^ This gives 147

```ruby
# frozen_string_literal: true
def test()
  "a" == "b"
end
#...
p stat2[:count] - stat1[:count] # number of GC sweeps (minor + major)
```

^ This gives 0


----


```ruby
def test(options = {})
end
GC.start
stat1 = GC.stat
1000_000.times do
  test
end
stat2 = GC.stat
p stat2[:count] - stat1[:count] # number of GC sweeps (minor + major) 
```

^ This gives 73

```ruby
EMPTY_HASH = {}.freeze
def test(options = EMPTY_HASH)
end
#...
p stat2[:count] - stat1[:count] # number of GC sweeps (minor + major) 
```

^ This gives 0

It would be nice if ruby has magic comment for this case too, like `# frozen_argument_hash: true` instead of this `EMPTY_HASH` hack