### PR TITLE
Fix lambda doc example

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -140,7 +140,7 @@ module I18n
     # called and passed the key and options.
     #
     # E.g. assuming the key <tt>:salutation</tt> resolves to:
-    #   lambda { |key, options| options[:gender] == 'm' ? "Mr. %{options[:name]}" : "Mrs. %{options[:name]}" }
+    #   lambda { |key, options| options[:gender] == 'm' ? "Mr. #{options[:name]}" : "Mrs. #{options[:name]}" }
     #
     # Then <tt>I18n.t(:salutation, :gender => 'w', :name => 'Smith') will result in "Mrs. Smith".
     #

--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -144,6 +144,10 @@ module I18n
     #
     # Then <tt>I18n.t(:salutation, :gender => 'w', :name => 'Smith') will result in "Mrs. Smith".
     #
+    # Note that the string returned by lambda will go through string interpolation too,
+    # so the following lambda would give the same result:
+    #   lambda { |key, options| options[:gender] == 'm' ? "Mr. %{name}" : "Mrs. %{name}" }
+    #
     # It is recommended to use/implement lambdas in an "idempotent" way. E.g. when
     # a cache layer is put in front of I18n.translate it will generate a cache key
     # from the argument values passed to #translate. Therefor your lambdas should


### PR DESCRIPTION
The lambda example uses standard Ruby interpolation therefore should use `#{}`.

I also added extra doc so it is clear that the lambda return string will still go through gem's own `%{}` interpolation.