### PR TITLE
Fix issue with disabled subtrees and pluralization for KeyValue backend

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -34,16 +34,16 @@ module I18n
           entry = resolve(locale, key, entry, options)
         end
 
+        entry = entry.dup if entry.is_a?(String)
+
+        count = options[:count]
+        entry = pluralize(locale, entry, count) if count
+
         if entry.nil?
           if (options.key?(:default) && !options[:default].nil?) || !options.key?(:default)
             throw(:exception, I18n::MissingTranslation.new(locale, key, options))
           end
         end
-
-        entry = entry.dup if entry.is_a?(String)
-
-        count = options[:count]
-        entry = pluralize(locale, entry, count) if count
 
         deep_interpolation = options[:deep_interpolation]
         values = options.except(*RESERVED_KEYS)

--- a/test/backend/key_value_test.rb
+++ b/test/backend/key_value_test.rb
@@ -40,4 +40,10 @@ class I18nBackendKeyValueTest < I18n::TestCase
       I18n.t("foo", :raise => true)
     end
   end
+
+  test "translate handles subtrees for pluralization" do
+    setup_backend!(false)
+    store_translations(:en, :bar => { :one => "One" })
+    assert_equal("One", I18n.t("bar", :count => 1))
+  end
 end if I18n::TestCase.key_value?


### PR DESCRIPTION
Fixes https://github.com/svenfuchs/i18n/issues/325.

The idea behind the fix, roughly speaking: for `KeyValue#lookup` when value was not found and subtrees are disabled to return some kind of lazy wrapper around possible existing subtree, instead of nil, to check against when searching pluralizations.

I'm not super confident about implementation and possibly this can be done in a better way.