### PR TITLE
Fix Chained backend with KeyValue

### DIFF
--- a/lib/i18n/backend/key_value.rb
+++ b/lib/i18n/backend/key_value.rb
@@ -103,6 +103,10 @@ module I18n
 
       protected
 
+        def subtrees?
+          @subtrees
+        end
+
         def lookup(locale, key, scope = [], options = {})
           key   = normalize_flat_keys(locale, key, scope, options[:separator])
           value = @store["#{locale}.#{key}"]
@@ -114,6 +118,15 @@ module I18n
             value
           elsif !@subtrees
             SubtreeProxy.new("#{locale}.#{key}", @store)
+          end
+        end
+
+        def pluralize(locale, entry, count)
+          if subtrees?
+            super
+          else
+            key = pluralization_key(entry, count)
+            entry[key]
           end
         end
       end
@@ -132,7 +145,10 @@ module I18n
         def [](key)
           unless @subtree && value = @subtree[key]
             value = @store["#{@master_key}.#{key}"]
-            (@subtree ||= {})[key] = JSON.decode(value) if value
+            if value
+              value = JSON.decode(value)
+              (@subtree ||= {})[key] = value
+            end
           end
           value
         end

--- a/test/backend/chain_test.rb
+++ b/test/backend/chain_test.rb
@@ -13,7 +13,7 @@ class I18nBackendChainTest < I18n::TestCase
     })
     @second = backend(:en => {
       :bar => 'Bar', :formats => {
-        :long => 'long', 
+        :long => 'long',
         :subformats => {:long => 'long'},
       },
       :plural_2 => { :one => 'one' },
@@ -89,3 +89,34 @@ class I18nBackendChainTest < I18n::TestCase
       backend
     end
 end
+
+class I18nBackendChainWithKeyValueTest < I18n::TestCase
+  def setup_backend!(subtrees = true)
+    first = I18n::Backend::KeyValue.new({}, subtrees)
+    first.store_translations(:en, :plural_1 => { :one => '%{count}' })
+
+    second = I18n::Backend::Simple.new
+    second.store_translations(:en, :plural_2 => { :one => 'one' })
+    I18n.backend = I18n::Backend::Chain.new(first, second)
+  end
+
+  test "subtrees enabled: looks up pluralization translations from the first chained backend" do
+    setup_backend!
+    assert_equal '1', I18n.t(:plural_1, count: 1)
+  end
+
+  test "subtrees disabled: looks up pluralization translations from the first chained backend" do
+    setup_backend!(false)
+    assert_equal '1', I18n.t(:plural_1, count: 1)
+  end
+
+  test "subtrees enabled: looks up translations from the second chained backend" do
+    setup_backend!
+    assert_equal 'one', I18n.t(:plural_2, count: 1)
+  end
+
+  test "subtrees disabled: looks up translations from the second chained backend" do
+    setup_backend!(false)
+    assert_equal 'one', I18n.t(:plural_2, count: 1)
+  end
+end if I18n::TestCase.key_value?

--- a/test/backend/key_value_test.rb
+++ b/test/backend/key_value_test.rb
@@ -41,6 +41,18 @@ class I18nBackendKeyValueTest < I18n::TestCase
     end
   end
 
+  test "subtrees enabled: given incomplete pluralization data it raises I18n::InvalidPluralizationData" do
+    setup_backend!
+    store_translations(:en, :bar => { :one => "One" })
+    assert_raise(I18n::InvalidPluralizationData) { I18n.t(:bar, :count => 2) }
+  end
+
+  test "subtrees disabled: given incomplete pluralization data it returns an error message" do
+    setup_backend!(false)
+    store_translations(:en, :bar => { :one => "One" })
+    assert_equal "translation missing: en.bar", I18n.t(:bar, :count => 2)
+  end
+
   test "translate handles subtrees for pluralization" do
     setup_backend!(false)
     store_translations(:en, :bar => { :one => "One" })


### PR DESCRIPTION
Fixes https://github.com/svenfuchs/i18n/issues/405.

With disabled subtrees, when we translate with `count` and composed key is not found - we cannot easily tell: is "pluralized" key missing or we don't have that key at all. So let raise an `I18n::MissingTranslation` error and allow the next backend in chain to handle this translation.

This is similar to previous behavior (before https://github.com/svenfuchs/i18n/pull/402), except that now it handles pluralized translations.

Correct me if I'm wrong or explained not clearly. 