### PR TITLE
store translations for unavailable locales if enforce_available_locales is false

### DIFF
--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -29,7 +29,8 @@ module I18n
         # translations will be overwritten by new ones only at the deepest
         # level of the hash.
         def store_translations(locale, data, options = {})
-          if I18n.available_locales_initialized? &&
+          if I18n.enforce_available_locales &&
+            I18n.available_locales_initialized? &&
             !I18n.available_locales.include?(locale.to_sym) &&
             !I18n.available_locales.include?(locale.to_s)
             return data

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -70,12 +70,23 @@ class I18nBackendSimpleTest < I18n::TestCase
     assert_equal Hash[:'en', {:foo => {:bar => 'bar', :baz => 'baz'}}], translations
   end
 
-  test "simple store_translations: do not store translations for locales not explicitly marked as available" do
+  test "simple store_translations: do not store translations unavailable locales if enforce_available_locales is true" do
+    begin
+      I18n.enforce_available_locales = true
+      I18n.available_locales = [:en, :es]
+      store_translations(:fr, :foo => {:bar => 'barfr', :baz => 'bazfr'})
+      store_translations(:es, :foo => {:bar => 'bares', :baz => 'bazes'})
+      assert_nil translations[:fr]
+      assert_equal Hash[:foo, {:bar => 'bares', :baz => 'bazes'}], translations[:es]
+    ensure
+      I18n.config.enforce_available_locales = false
+    end
+  end
+
+  test "simple store_translations: store translations for unavailable locales if enforce_available_locales is false" do
     I18n.available_locales = [:en, :es]
     store_translations(:fr, :foo => {:bar => 'barfr', :baz => 'bazfr'})
-    store_translations(:es, :foo => {:bar => 'bares', :baz => 'bazes'})
-    assert_nil translations[:fr]
-    assert_equal Hash[:foo, {:bar => 'bares', :baz => 'bazes'}], translations[:es]
+    assert_equal Hash[:foo, {:bar => 'barfr', :baz => 'bazfr'}], translations[:fr]
   end
 
   # reloading translations


### PR DESCRIPTION
Fixes issue described in #404 where the `enforce_available_locales` setting is not respected by the optimization added in #391.

Adds `I18n.enforce_available_locales &&` to the early-exit conditional in `#store_translations`, so that translations for locales not in the `available_locales` array will not be stored only if `enforce_available_locales` is set to `true`.

Updated tests to reflect changed behavior.