### PR TITLE
Remove Ruby 1.9.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.10
   - 2.2.8
@@ -26,20 +25,14 @@ gemfile:
 matrix:
   exclude:
     # Rails 5+ requires Ruby >= 2.2.2
-    - rvm: 1.9.3
-      gemfile: gemfiles/Gemfile.rails-master
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.rails-master
     - rvm: 2.1.10
       gemfile: gemfiles/Gemfile.rails-master
-    - rvm: 1.9.3
-      gemfile: gemfiles/Gemfile.rails-5.0.x
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.rails-5.0.x
     - rvm: 2.1.10
       gemfile: gemfiles/Gemfile.rails-5.0.x
-    - rvm: 1.9.3
-      gemfile: gemfiles/Gemfile.rails-5.1.x
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.rails-5.1.x
     - rvm: 2.1.10

--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.rubyforge_project = '[none]'
   s.required_rubygems_version = '>= 1.3.5'
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.add_dependency 'concurrent-ruby', '~> 1.0'
 end


### PR DESCRIPTION
It's time to remove support for Ruby 1.9.x.

This version of Ruby was initially released in 2008 (if my memory serves) and the [Ruby maintainers have EOL'd Ruby](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/) from Feb 23rd, 2015. It's time we did the same.

This will be the _only_ commit differentiating 0.9.5 and 1.0.0.

I'm choosing to release this as 1.0.0 to ensure that backwards compatibility with older versions of Rails is kept.