### PR TITLE
Interpolation add missing reserved key

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -14,7 +14,21 @@ module I18n
   autoload :Tests,   'i18n/tests'
   autoload :Middleware,   'i18n/middleware'
 
-  RESERVED_KEYS = [:scope, :default, :separator, :resolve, :object, :fallback, :fallback_in_progress, :format, :cascade, :throw, :raise, :deep_interpolation]
+  RESERVED_KEYS = %i[
+    cascade
+    deep_interpolation
+    default
+    exception_handler
+    fallback
+    fallback_in_progress
+    format
+    object
+    raise
+    resolve
+    scope
+    separator
+    throw
+  ].freeze
   RESERVED_KEYS_PATTERN = /%\{(#{RESERVED_KEYS.join("|")})\}/
   EMPTY_HASH = {}.freeze
 

--- a/lib/i18n/backend/metadata.rb
+++ b/lib/i18n/backend/metadata.rb
@@ -44,7 +44,7 @@ module I18n
           :scope     => options[:scope],
           :default   => options[:default],
           :separator => options[:separator],
-          :values    => options.reject { |name, value| RESERVED_KEYS.include?(name) }
+          :values    => options.reject { |name, _value| RESERVED_KEYS.include?(name) }
         }
         with_metadata(metadata) { super }
       end

--- a/lib/i18n/tests/interpolation.rb
+++ b/lib/i18n/tests/interpolation.rb
@@ -104,9 +104,10 @@ module I18n
       end
 
       test "interpolation: given a translations containing a reserved key it raises I18n::ReservedInterpolationKey" do
-        assert_raise(I18n::ReservedInterpolationKey) { interpolate(:default => '%{default}',   :foo => :bar) }
-        assert_raise(I18n::ReservedInterpolationKey) { interpolate(:default => '%{scope}',     :foo => :bar) }
-        assert_raise(I18n::ReservedInterpolationKey) { interpolate(:default => '%{separator}', :foo => :bar) }
+        assert_raise(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{exception_handler}') }
+        assert_raise(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{default}') }
+        assert_raise(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{separator}') }
+        assert_raise(I18n::ReservedInterpolationKey) { interpolate(:foo => :bar, :default => '%{scope}') }
       end
 
       test "interpolation: deep interpolation for default string" do


### PR DESCRIPTION
Add `:exception_handler` to the `RESERVED_KEYS` constant.

Based on https://github.com/svenfuchs/i18n/blob/master/lib/i18n/tests/interpolation.rb

```
# If no interpolation parameter is not given, I18n should not alter the string.
# This behavior is due to three reasons:
#
#   * Checking interpolation keys in all strings hits performance, badly;
#
#   * This allows us to retrieve untouched values through I18n. For example
#     I could have a middleware that returns I18n lookup results in JSON
#     to be processed through Javascript. Leaving the keys untouched allows
#     the interpolation to happen at the javascript level;
#
#   * Security concerns: if I allow users to translate a web site, they can
#     insert %{} in messages causing the I18n lookup to fail in every request.
#
```

Passing in a non-interpolation related custom exception handler for a translation would trip the interpolation behaviour when it is unexpected.

It took me a while to understand what was happening, I would suggest to rename the constants toward "interpolation" or move them in lib/i18n/interpolate/ruby.rb.