### PR TITLE
[WIP] defaults take precedence over fallbacks causing a misleading situation

### DIFF
--- a/lib/i18n/tests/defaults.rb
+++ b/lib/i18n/tests/defaults.rb
@@ -5,7 +5,8 @@ module I18n
     module Defaults
       def setup
         super
-        I18n.backend.store_translations(:en, :foo => { :bar => 'bar', :baz => 'baz' })
+        I18n.backend.store_translations(:en, :foo => { :bar => 'bar', :baz => 'baz' }, faa: 'i exist')
+        I18n.backend.store_translations(:'en-CH', :foo => { :bar => 'bar', :baz => 'baz' })
       end
 
       test "defaults: given nil as a key it returns the given default" do

--- a/test/api/fallbacks_test.rb
+++ b/test/api/fallbacks_test.rb
@@ -22,6 +22,20 @@ class I18nFallbacksApiTest < I18n::TestCase
   include I18n::Tests::Localization::Time
   include I18n::Tests::Localization::Procs
 
+  test "fallback does not work with defaults when using en-CH locale" do
+    I18n.with_locale(:'en-CH') do
+      assert_equal 'i exist', I18n.t(:faa)
+      assert_equal 'i exist', I18n.t(:faa, :default => [:'foo.bar'])
+    end
+  end
+
+  test "fallback works with defaults when using en locale" do
+    I18n.with_locale(:en) do
+      assert_equal 'i exist', I18n.t(:faa)
+      assert_equal 'i exist', I18n.t(:faa, :default => [:'foo.bar'])
+    end
+  end
+
   test "make sure we use a backend with Fallbacks included" do
     assert_equal Backend, I18n.backend.class
   end


### PR DESCRIPTION
Before proceeding with fixing the issues (even if I would need help with that) I opened a pull request with a failing test to explain it better.
The failing test is on line 28 (https://github.com/svenfuchs/i18n/compare/master...coorasse:add_fallback_issue_example#diff-514ab2ee25f5643b31473b6383cf04e7R28) and, as you can see, it shouldn't fail, since the test on the previous line works fine.
In other words: if I have a string translated, I don't expect it not to be translated because I add a default value.
That unfortunately happened in our Rails app and took me some time to dig into the issue.
Funny fact: when using a Chain backend `I18n.backend = I18n::Backend::Chain.new(Backend.new, I18n::Backend::Simple.new)` the same does not happen since the `default` options are passed only to the last backend of the chain.
