### PR TITLE
Simplify default exception handler

### DIFF
--- a/lib/i18n/exceptions.rb
+++ b/lib/i18n/exceptions.rb
@@ -3,23 +3,14 @@
 require 'cgi'
 
 module I18n
-  # Handles exceptions raised in the backend. All exceptions except for
-  # MissingTranslationData exceptions are re-thrown. When a MissingTranslationData
-  # was caught the handler returns an error message string containing the key/scope.
-  # Note that the exception handler is not called when the option :throw was given.
   class ExceptionHandler
-    include Module.new {
-      def call(exception, locale, key, options)
-        case exception
-        when MissingTranslation
-          exception.message
-        when Exception
-          raise exception
-        else
-          throw :exception, exception
-        end
+    def call(exception, _locale, _key, _options)
+      if exception.is_a?(MissingTranslation)
+        exception.message
+      else
+        raise exception
       end
-    }
+    end
   end
 
   class ArgumentError < ::ArgumentError; end


### PR DESCRIPTION
I didn't track all of the historic of the `I18n::ExceptionHandler` but some of the code seems to have fallen out of touch with the current code logic.

The description refer to:
> All exceptions except for MissingTranslationData exceptions are re-thrown

Where in reality `MissingTranslationData` would get re-raised and `MissingTranslation` would not.

According to what I see, only 2 code paths can trigger this code path:
https://github.com/svenfuchs/i18n/blob/274ed8accd53a573d839617de2dd16b1b01d864b/lib/i18n.rb#L174 (`MissingTranslation`)
https://github.com/svenfuchs/i18n/blob/274ed8accd53a573d839617de2dd16b1b01d864b/lib/i18n.rb#L251 (`I18n::ArgumentError`)

`MissingTranslation` being a `I18n::ArgumentError`, the order need to be for `MissingTranslation` to be processed first. 

`throw :exception, exception` would be a dead code path?
