### PR TITLE
Fallbacks to exclude default locale

### DIFF
--- a/lib/i18n/locale/fallbacks.rb
+++ b/lib/i18n/locale/fallbacks.rb
@@ -56,7 +56,7 @@ module I18n
       def initialize(*mappings)
         @map = {}
         map(mappings.pop) if mappings.last.is_a?(Hash)
-        self.defaults = mappings.empty? ? [I18n.default_locale.to_sym] : mappings
+        self.defaults = mappings.empty? ? [] : mappings
       end
 
       def defaults=(defaults)

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -24,16 +24,8 @@ class I18nBackendFallbacksTranslateTest < I18n::TestCase
     assert_equal 'Interpolate %{value}', I18n.t(:interpolate)
   end
 
-  test "returns the :en translation for a missing :de translation" do
-    assert_equal 'Foo in :en', I18n.t(:foo, :locale => :de)
-  end
-
   test "returns the :de translation for a missing :'de-DE' translation" do
     assert_equal 'Bar in :de', I18n.t(:bar, :locale => :'de-DE')
-  end
-
-  test "returns the :en translation for translation missing in both :de and :'de-De'" do
-    assert_equal 'Buz in :en', I18n.t(:buz, :locale => :'de-DE')
   end
 
   test "returns the :de translation for a missing :'de-DE' when :default is a String" do
@@ -117,18 +109,13 @@ class I18nBackendFallbacksLocalizeTest < I18n::TestCase
     super
     I18n.backend = Backend.new
     store_translations(:en, :date => { :formats => { :en => 'en' }, :day_names => %w(Sunday) })
-    store_translations(:de, :date => { :formats => { :de => 'de' } })
+    store_translations(:de, :date => { :formats => { :de => 'de' }, :day_names => %w(Sunday) })
   end
 
   test "still uses an existing format as usual" do
     assert_equal 'en', I18n.l(Date.today, :format => :en, :locale => :en)
   end
-
-  test "looks up and uses a fallback locale's format for a key missing in the given locale (1)" do
-    assert_equal 'en', I18n.l(Date.today, :format => :en, :locale => :de)
-  end
-
-  test "looks up and uses a fallback locale's format for a key missing in the given locale (2)" do
+  test "looks up and uses a fallback locale's format for a key missing in the given locale" do
     assert_equal 'de', I18n.l(Date.today, :format => :de, :locale => :'de-DE')
   end
 
@@ -137,7 +124,7 @@ class I18nBackendFallbacksLocalizeTest < I18n::TestCase
   end
 
   test "uses a fallback locale's translation for a key missing in the given locale" do
-    assert_equal 'Sunday', I18n.l(Date.new(2010, 1, 3), :format => '%A', :locale => :de)
+    assert_equal 'Sunday', I18n.l(Date.new(2010, 1, 3), :format => '%A', :locale => :'de-DE')
   end
 end
 
@@ -208,8 +195,8 @@ class I18nBackendFallbacksExistsTest < I18n::TestCase
   end
 
   test "exists? should return true given a key which is missing from the given locale and exists in a fallback locale" do
-    assert_equal true, I18n.exists?(:foo, :de)
-    assert_equal true, I18n.exists?(:foo, :'de-DE')
+    assert_equal true, I18n.exists?(:bar, :de)
+    assert_equal true, I18n.exists?(:bar, :'de-DE')
   end
 
   test "exists? should return false given a key which is missing from the given locale and all its fallback locales" do

--- a/test/locale/fallbacks_test.rb
+++ b/test/locale/fallbacks_test.rb
@@ -3,10 +3,10 @@ require 'test_helper'
 include I18n::Locale
 
 class I18nFallbacksDefaultsTest < I18n::TestCase
-  test "defaults reflect the I18n.default_locale if no default has been set manually" do
+  test "defaults to an empty array if no default has been set manually" do
     I18n.default_locale = :'en-US'
     fallbacks = Fallbacks.new
-    assert_equal [:'en-US', :en], fallbacks.defaults
+    assert_equal [], fallbacks.defaults
   end
 
   test "defaults reflect a manually passed default locale if any" do


### PR DESCRIPTION
Fixes https://github.com/svenfuchs/i18n/issues/338 ?

I believe using the default locale as a default fallback is not a sane default behaviour.

"Silently" displaying an default locale version of a string when a page is being rendered in another can have a negative impact (especially if this is not fixable like in the cases where emails are being sent).

For us to disable that behaviour, we had to pass in an explicit `nil`, but I believe it should be the default behaviour:
```rb
I18n::Locale::Fallbacks.new([nil])
or
Rails.application.config.i18n.fallbacks = [nil]
```
This only work because of a undocumented `compact` down in the internals of the class.

I am not saying that I would always prefer to have a "translation missing" error instead of displaying the default locale, but not having the default allows the rest of the i18n stack to handle exceptions as normal, send it to the exception handler where I can transform that missing translation to the specificities of my application.

Eg.: in my current case we have an exception handler that logs on missing translation, send a developer actionable item then manually fall back to `I18n.t(key, options.merge(locale: :en)`, all within the `I18n.exception_handler#call`
