### PR TITLE
Fix deprecated use of assert_nothing_raised

### DIFF
--- a/lib/i18n/tests/interpolation.rb
+++ b/lib/i18n/tests/interpolation.rb
@@ -43,7 +43,7 @@ module I18n
       end
 
       test "interpolation: it does not raise I18n::MissingInterpolationArgument for escaped variables" do
-        assert_nothing_raised(I18n::MissingInterpolationArgument) do
+        assert_nothing_raised do
           assert_equal 'Barr %{foo}', interpolate(:default => '%{bar} %%{foo}', :bar => 'Barr')
         end
       end


### PR DESCRIPTION
Here we go, following #416 

I have other questions tho, in https://github.com/svenfuchs/i18n/blob/master/test/test_helper.rb#L11 I see that `assert_nothing_raised` is defined but we are in the `/test` directory... if I follow correctly the tests defined in `/test` use a different test library than in `/lib/i18n/tests`?