### PR TITLE
Fix pluralization behavior for KeyValue backend with subtrees disabled

### DIFF
--- a/lib/i18n/backend/key_value.rb
+++ b/lib/i18n/backend/key_value.rb
@@ -127,6 +127,7 @@ module I18n
           if subtrees?
             super
           else
+            return entry unless entry.is_a?(Hash)
             key = pluralization_key(entry, count)
             entry[key]
           end

--- a/test/backend/fallbacks_test.rb
+++ b/test/backend/fallbacks_test.rb
@@ -98,6 +98,11 @@ class I18nBackendFallbacksTranslateTest < I18n::TestCase
       I18n.enforce_available_locales = false
     end
   end
+
+  test "returns fallback default given missing pluralization data" do
+    assert_equal 'default', I18n.t(:missing_bar, count: 1, default: 'default')
+    assert_equal 'default', I18n.t(:missing_bar, count: 0, default: 'default')
+  end
 end
 
 class I18nBackendFallbacksLocalizeTest < I18n::TestCase

--- a/test/backend/key_value_test.rb
+++ b/test/backend/key_value_test.rb
@@ -58,4 +58,28 @@ class I18nBackendKeyValueTest < I18n::TestCase
     store_translations(:en, :bar => { :one => "One" })
     assert_equal("One", I18n.t("bar", :count => 1))
   end
+  
+  test "subtrees enabled: returns localized string given missing pluralization data" do
+    setup_backend!(true)
+    assert_equal 'bar', I18n.t("foo.bar", count: 1)
+  end
+
+  test "subtrees disabled: returns localized string given missing pluralization data" do
+    setup_backend!(false)
+    assert_equal 'bar', I18n.t("foo.bar", count: 1)
+  end
+  
+  test "subtrees enabled: Returns fallback default given missing pluralization data" do
+    setup_backend!(true)
+    I18n.backend.extend I18n::Backend::Fallbacks
+    assert_equal 'default', I18n.t(:missing_bar, count: 1, default: 'default')
+    assert_equal 'default', I18n.t(:missing_bar, count: 0, default: 'default')
+  end
+
+  test "subtrees disabled: Returns fallback default given missing pluralization data" do
+    setup_backend!(false)
+    I18n.backend.extend I18n::Backend::Fallbacks
+    assert_equal 'default', I18n.t(:missing_bar, count: 1, default: 'default')
+    assert_equal 'default', I18n.t(:missing_bar, count: 0, default: 'default')
+  end
 end if I18n::TestCase.key_value?

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -100,4 +100,8 @@ class I18nBackendSimpleTest < I18n::TestCase
     I18n.backend.reload!
     assert_equal false, I18n.backend.initialized?
   end
+
+  test "returns localized string given missing pluralization data" do
+    assert_equal 'baz', I18n.t('foo.bar', count: 1)
+  end
 end


### PR DESCRIPTION
This PR includes a fix making the pluralization behavior for the `KeyValue` backend with subtrees disabled conform more closely to the behavior of the default `Simple` backend, as well as the `KeyValue` backend with subtrees enabled.

My use-case for this PR is migrating an existing application from a `Simple` to a `KeyValue` backend with subtrees disabled for performance, where the existing application depends on specific fallback/pluralization semantics to run without further modification.

The simple code change to `key_value.rb` fixes the following two errors, which I've reproduced in the added tests:

```
  1) Error:
 I18nBackendKeyValueTest#test_subtrees_disabled:_Returns_fallback_default_given_missing_pluralization_data:
NoMethodError: undefined method `[]' for nil:NilClass
    [Code]/i18n/lib/i18n/backend/key_value.rb:131:in `pluralize'
    [Code]/i18n/lib/i18n/backend/base.rb:48:in `translate'
    [Code]/i18n/lib/i18n/backend/fallbacks.rb:48:in `block (2 levels) in translate'
    [Code]/i18n/lib/i18n/backend/fallbacks.rb:47:in `catch'
    [Code]/i18n/lib/i18n/backend/fallbacks.rb:47:in `block in translate'
    [Code]/i18n/lib/i18n/backend/fallbacks.rb:45:in `each'
    [Code]/i18n/lib/i18n/backend/fallbacks.rb:45:in `translate'
    [Code]/i18n/lib/i18n.rb:185:in `block in translate'
    [Code]/i18n/lib/i18n.rb:181:in `catch'
    [Code]/i18n/lib/i18n.rb:181:in `translate'
    [Code]/i18n/test/backend/key_value_test.rb:81:in `block in <class:I18nBackendKeyValueTest>'

  2) Error:
I18nBackendKeyValueTest#test_subtrees_disabled:_returns_localized_string_given_missing_pluralization_data:
TypeError: no implicit conversion of Symbol into Integer
    [Code]/i18n/lib/i18n/backend/key_value.rb:131:in `[]'
    [Code]/i18n/lib/i18n/backend/key_value.rb:131:in `pluralize'
    [Code]/i18n/lib/i18n/backend/base.rb:48:in `translate'
    [Code]/i18n/lib/i18n.rb:185:in `block in translate'
    [Code]/i18n/lib/i18n.rb:181:in `catch'
    [Code]/i18n/lib/i18n.rb:181:in `translate'
    [Code]/i18n/test/backend/key_value_test.rb:69:in `block in <class:I18nBackendKeyValueTest>'
```