### PR TITLE
add FileKeyValue backend

### DIFF
--- a/lib/i18n/backend.rb
+++ b/lib/i18n/backend.rb
@@ -8,6 +8,7 @@ module I18n
     autoload :Cascade,               'i18n/backend/cascade'
     autoload :Chain,                 'i18n/backend/chain'
     autoload :Fallbacks,             'i18n/backend/fallbacks'
+    autoload :FileKeyValue,          'i18n/backend/file_key_value'
     autoload :Flatten,               'i18n/backend/flatten'
     autoload :Gettext,               'i18n/backend/gettext'
     autoload :KeyValue,              'i18n/backend/key_value'

--- a/lib/i18n/backend/file_key_value.rb
+++ b/lib/i18n/backend/file_key_value.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'digest/sha2'
+
+module I18n
+  module Backend
+    # Backend for a key-value store that automatically loads
+    # its contents from Ruby or YAML files on the I18n load path.
+    # Since the same source translation files are used, this backend is a
+    # fully compatible drop-in replacement for the Simple backend.
+    #
+    # Compared to the Simple backend, this backend can reduce memory usage,
+    # since translations are loaded to a key-value store instead of a Hash.
+    #
+    # It can also reduce startup time, since source translation files are
+    # only reloaded when the file contents change.
+    class FileKeyValue < KeyValue
+      def initialize(store, subtrees = true, path_roots = nil)
+        super(store, subtrees)
+        @path_roots = path_roots
+      end
+
+      def load_translations(*filenames)
+        translations = buffer { super }
+        return if translations.empty?
+        with_transaction do
+          translations.each do |locale, data|
+            backend_store_translations(locale, data)
+          end
+        end
+      end
+
+      alias reload! load_translations
+      alias init_translations load_translations
+
+      alias backend_store_translations store_translations
+
+      # Store translations to buffer if available.
+      def store_translations(locale, data, options = EMPTY_HASH)
+        if @buffer
+          @buffer.store_translations(locale, data, options)
+        else
+          super
+        end
+      end
+
+      protected
+
+      # Track loaded translation files in the `i18n.load_file` scope,
+      # and skip loading the file if its contents are still up-to-date.
+      def load_file(filename)
+        key = escape_default_separator(normalized_path(filename))
+        old_mtime, old_digest = lookup(:i18n, key, :load_file)
+        return if (mtime = File.mtime(filename).to_i) == old_mtime ||
+                  (digest = Digest::SHA2.file(filename).hexdigest) == old_digest
+        super
+        store_translations(:i18n, load_file: { key => [mtime, digest] })
+      end
+
+      # Translate absolute filename to relative path for i18n key
+      # to make the cached i18n data portable across environments.
+      def normalized_path(file)
+        return file unless @path_roots
+        path = @path_roots.find(&file.method(:start_with?)) ||
+               raise(InvalidLocaleData.new(file, 'outside expected path roots'))
+        file.sub(path, @path_roots.index(path).to_s)
+      end
+
+      # Buffer all translations loaded within the provided block,
+      # using an in-memory hash from a Backend::Simple instance.
+      def buffer
+        @buffer = I18n::Backend::Simple.new
+        yield if block_given?
+        @buffer.send(:translations)
+      ensure
+        @buffer = nil
+      end
+
+      # Call block with store#transaction if available.
+      def with_transaction(&block)
+        store.respond_to?(:transaction) ? store.transaction(&block) : yield
+      end
+    end
+  end
+end

--- a/test/backend/file_key_value_test.rb
+++ b/test/backend/file_key_value_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class FileKeyValueTest < I18n::TestCase
+  class SimpleHashStore < Hash
+    attr_reader :transactions, :reads, :writes
+
+    def initialize
+      super
+      @transactions = @reads = @writes = 0
+    end
+
+    def transaction
+      yield.tap { @transactions += 1 }
+    end
+
+    def [](key)
+      super.tap { @reads += 1 }
+    end
+
+    def []=(key, value)
+      super.tap { @writes += 1 }
+    end
+  end
+
+  def setup_backend!(subtrees = false)
+    @store = SimpleHashStore.new
+    I18n.backend = I18n::Backend::FileKeyValue.new(@store, subtrees, [locales_dir])
+  end
+
+  test 'basic store_translations functionality' do
+    setup_backend!
+    store_translations(:en, :foo => { :baz => 'BAZ'})
+    assert_equal('BAZ', I18n.t('foo.baz'))
+    assert_equal 1, @store.writes
+    assert_equal 1, @store.reads
+    assert_equal 0, @store.transactions
+  end
+
+  test 'store_translations with subtrees disabled' do
+    setup_backend!
+    store_translations(:en, foo: { bar: { baz: 'BAZ' } })
+    assert_equal('translation missing: en.foo', I18n.t('foo'))
+    assert_raise I18n::MissingTranslationData do
+      I18n.t('foo', raise: true)
+    end
+  end
+
+  test 'store_translations with subtrees enabled' do
+    setup_backend!(true)
+    store_translations(:en, foo: { baa: 'BAB' })
+    store_translations(:en, foo: { bar: {baz: 'BAZ'} })
+    assert_equal({ bar: {baz: 'BAZ' }, baa: 'BAB' }, I18n.t('foo'))
+    assert_equal 4, @store.reads
+    assert_equal 5, @store.writes
+  end
+
+  test 'load_translations' do
+    setup_backend!
+    I18n.load_path = [locales_dir + '/en.yml']
+    assert_equal('baz', I18n.t('foo.bar'))
+    assert_equal 2, @store.writes
+    assert_equal 1, @store.transactions
+
+    I18n.backend.reload!
+    assert_equal 2, @store.writes
+    assert_equal 1, @store.transactions
+  end
+  
+  test 'hash store without #transaction' do
+    setup_backend!
+    I18n.backend.store = {}
+    I18n.load_path = [locales_dir + '/en.yml']
+    assert_equal('baz', I18n.t('foo.bar'))
+  end
+end if I18n::TestCase.key_value?


### PR DESCRIPTION
This PR adds a new `FileKeyValue` backend. This backend is designed to seamlessly migrate an existing application using the default `Simple` backend to a disk-based key-value store to improve per-process memory usage and application startup time.

## Description
Backend for a key-value store that automatically loads its contents from Ruby or YAML files on the I18n load path. Since the same source translation files are used, this backend is a fully compatible drop-in replacement for the Simple backend.

Compared to the Simple backend, this backend can reduce memory usage, since translations are loaded to a key-value store instead of a Hash.

It can also reduce startup time, since source translation files are only reloaded when the file contents change.

## Notes

- Not committed to the name yet, could use other suggestions.
- The tests provide 100% line-by-line coverage, but don't yet thoroughly cover some of the more complex edge cases (modified file without changing contents, ensuring multiple file-loads are batched in single transaction, etc). If there's any interest in this backend, I'm happy to build out the tests to cover the rest of these edge-cases more thoroughly.
- The implementation extends the existing KeyValue implementation, reusing its existing `store_translations` method.
- The `Simple` backend is used internally to buffer newly-loaded translations in memory, before they are all written out in a single transaction. This optimization helps improve performance with many key-value stores.
- My use-case for developing this backend is to improve per-process memory-usage (and less important, startup time) of a large, heavily-localized Rails application loading ~500mb of localization data stored in `.yml` files, with minimal application changes.