### PR TITLE
support translation hashes with numeric keys in Simple backend

### DIFF
--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -39,7 +39,7 @@ module I18n
           end
           locale = locale.to_sym
           translations[locale] ||= {}
-          data = data.deep_symbolize_keys
+          data = data.deep_stringify_keys.deep_symbolize_keys
           translations[locale].deep_merge!(data)
         end
 

--- a/lib/i18n/core_ext/hash.rb
+++ b/lib/i18n/core_ext/hash.rb
@@ -17,6 +17,14 @@ class Hash
     }
   end unless Hash.method_defined?(:deep_symbolize_keys)
 
+  def deep_stringify_keys
+    inject({}) { |result, (key, value)|
+      value = value.deep_stringify_keys if value.is_a?(Hash)
+      result[key.to_s] = value
+      result
+    }
+  end unless Hash.method_defined?(:deep_stringify_keys)
+
   # deep_merge_hash! by Stefan Rusterholz, see http://www.ruby-forum.com/topic/142809
   MERGER = proc do |key, v1, v2|
     Hash === v1 && Hash === v2 ? v1.merge(v2, &MERGER) : v2

--- a/test/backend/key_value_test.rb
+++ b/test/backend/key_value_test.rb
@@ -21,6 +21,14 @@ class I18nBackendKeyValueTest < I18n::TestCase
     assert_flattens({:"a.b"=>['a', 'b']}, {:a=>{:b =>['a', 'b']}}, true, false)
     assert_flattens({:"a.b" => "c"}, {:"a.b" => "c"}, false)
   end
+  
+  test "store_translations supports numeric keys" do
+    setup_backend!
+    store_translations(:en, 1 => 'foo')
+    assert_equal 'foo', I18n.t('1')
+    assert_equal 'foo', I18n.t(1)
+    assert_equal 'foo', I18n.t(:'1')
+  end
 
   test "store_translations handle subtrees by default" do
     setup_backend!

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -89,6 +89,13 @@ class I18nBackendSimpleTest < I18n::TestCase
     assert_equal Hash[:foo, {:bar => 'barfr', :baz => 'bazfr'}], translations[:fr]
   end
 
+  test "simple store_translations: supports numeric keys" do
+    store_translations(:en, 1 => 'foo')
+    assert_equal 'foo', I18n.t('1')
+    assert_equal 'foo', I18n.t(1)
+    assert_equal 'foo', I18n.t(:'1')
+  end
+
   # reloading translations
 
   test "simple reload_translations: unloads translations" do

--- a/test/core_ext/hash_test.rb
+++ b/test/core_ext/hash_test.rb
@@ -8,6 +8,12 @@ class I18nCoreExtHashInterpolationTest < I18n::TestCase
     assert_equal expected, hash.deep_symbolize_keys
   end
 
+  test "#deep_stringify_keys" do
+    hash = { :foo => { :bar => { :baz => 'bar' } } }
+    expected = { 'foo' => { 'bar' => { 'baz' => 'bar' } } }
+    assert_equal expected, hash.deep_stringify_keys
+  end
+
   test "#slice" do
     hash = { :foo => 'bar',  :baz => 'bar' }
     expected = { :foo => 'bar' }


### PR DESCRIPTION
Currently, loading a translation hash with a Numeric key (e.g., `store_translations(:en, 1 => 'foo'); I18n.t(1)`) does not work using the `Simple` backend, since the implementation's call to `deep_symbolize_keys` (to normalize all translation keys as Symbols) does not affect Numeric types (`Numeric#to_sym` is not implemented). This PR additionally calls `deep_stringify_keys` to help normalize key types implementing `to_s`.

This also brings the behavior of KeyValue and Simple backends slightly closer together, since numeric keys are already supported by the `KeyValue` backend.

I don't expect much of a performance hit from the added `deep_stringify_keys` operation. Surprisingly in tests with my use-case, I saw load times with this PR change actually improve by 25% (from 60 seconds to 45 seconds), possibly since the call to `deep_symbolize_keys` was no longer hitting the `NoMethodError` exception/ `rescue nil` code path for Numeric keys in my translation data.