### PR TITLE
add CacheFile backend module

### DIFF
--- a/lib/i18n/backend.rb
+++ b/lib/i18n/backend.rb
@@ -5,6 +5,7 @@ module I18n
     autoload :Base,                  'i18n/backend/base'
     autoload :InterpolationCompiler, 'i18n/backend/interpolation_compiler'
     autoload :Cache,                 'i18n/backend/cache'
+    autoload :CacheFile,             'i18n/backend/cache_file'
     autoload :Cascade,               'i18n/backend/cascade'
     autoload :Chain,                 'i18n/backend/chain'
     autoload :Fallbacks,             'i18n/backend/fallbacks'

--- a/lib/i18n/backend/cache_file.rb
+++ b/lib/i18n/backend/cache_file.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'digest/sha2'
+
+module I18n
+  module Backend
+    # Overwrites the Base load_file method to cache loaded file contents.
+    module CacheFile
+      # Optionally provide path_roots array to normalize filename paths,
+      # to make the cached i18n data portable across environments.
+      attr_accessor :path_roots
+
+      protected
+
+      # Track loaded translation files in the `i18n.load_file` scope,
+      # and skip loading the file if its contents are still up-to-date.
+      def load_file(filename)
+        initialized = !respond_to?(:initialized?) || initialized?
+        key = I18n::Backend::Flatten.escape_default_separator(normalized_path(filename))
+        old_mtime, old_digest = initialized && lookup(:i18n, key, :load_file)
+        return if (mtime = File.mtime(filename).to_i) == old_mtime ||
+                  (digest = Digest::SHA2.file(filename).hexdigest) == old_digest
+        super
+        store_translations(:i18n, load_file: { key => [mtime, digest] })
+      end
+
+      # Translate absolute filename to relative path for i18n key.
+      def normalized_path(file)
+        return file unless path_roots
+        path = path_roots.find(&file.method(:start_with?)) ||
+               raise(InvalidLocaleData.new(file, 'outside expected path roots'))
+        file.sub(path, path_roots.index(path).to_s)
+      end
+    end
+  end
+end

--- a/test/backend/cache_file_test.rb
+++ b/test/backend/cache_file_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+require 'fileutils'
+require 'tempfile'
+
+module CountWrites
+  attr_reader :writes
+
+  def initialize(*args)
+    super
+    @writes = []
+  end
+
+  def store_translations(*args)
+    super.tap { @writes << args }
+  end
+end
+
+module CacheFileTest
+  test 'load_translations caches loaded file contents' do
+    setup_backend!
+    I18n.load_path = [locales_dir + '/en.yml']
+    assert_equal 0, @backend.writes.count
+
+    @backend.load_translations unless @backend.is_a?(I18n::Backend::Simple)
+    assert_equal('baz', I18n.t('foo.bar'))
+    assert_equal 2, @backend.writes.count
+
+    @backend.load_translations
+    assert_equal('baz', I18n.t('foo.bar'))
+    assert_equal 2, @backend.writes.count
+  end
+
+  test 'setting path_roots normalizes write key' do
+    setup_backend!
+    I18n.load_path = [locales_dir + '/en.yml']
+    @backend.path_roots = [locales_dir]
+    @backend.load_translations
+    refute_nil I18n.t("0/en\x01yml", scope: :load_file, locale: :i18n, default: nil)
+  end
+
+  test 'load_translations caches file through updated modification time' do
+    setup_backend!
+    Tempfile.open(['test', '.yml']) do |file|
+      I18n.load_path = [file.path]
+
+      File.write(file, { :en => { :foo => { :bar => 'baz' } } }.to_yaml)
+      assert_equal 0, @backend.writes.count
+
+      @backend.load_translations unless @backend.is_a?(I18n::Backend::Simple)
+      assert_equal('baz', I18n.t('foo.bar'))
+      assert_equal 2, @backend.writes.count
+
+      FileUtils.touch(file, :mtime => Time.now + 1)
+      @backend.load_translations
+      assert_equal('baz', I18n.t('foo.bar'))
+      assert_equal 2, @backend.writes.count
+
+      File.write(file, { :en => { :foo => { :bar => 'baa' } } }.to_yaml)
+      FileUtils.touch(file, :mtime => Time.now + 1)
+      @backend.load_translations
+      assert_equal('baa', I18n.t('foo.bar'))
+      assert_equal 4, @backend.writes.count
+    end
+  end
+end
+
+class SimpleCacheFileTest < I18n::TestCase
+  include CacheFileTest
+
+  class Backend < I18n::Backend::Simple
+    include CountWrites
+    include I18n::Backend::CacheFile
+  end
+
+  def setup_backend!
+    @backend = I18n.backend = Backend.new
+  end
+end
+
+class KeyValueCacheFileTest < I18n::TestCase
+  include CacheFileTest
+
+  class Backend < I18n::Backend::KeyValue
+    include CountWrites
+    include I18n::Backend::CacheFile
+    def initialize
+      super({})
+    end
+  end
+
+  def setup_backend!
+    @backend = I18n.backend = Backend.new
+  end
+end if I18n::TestCase.key_value?


### PR DESCRIPTION
This PR adds a new backend module `CacheFile`. This module overwrites the `Base#load_file` method to store metadata of loaded file contents, and use this metadata to skip re-loading the same files when their contents haven't changed.

- The module works with `Simple` and `KeyValue` backends, though it's probably more useful in the latter (where the translation store persists across application restarts).
- Loaded-file metadata is stored in the i18n backend itself, using the `:18n` locale `:load_file` scope, with filename as key.
- When determining whether a file's contents have been changed, it first checks the file-modification time (using `File.mtime(filename).to_i`), and if they don't match, it additionally checks the file's content (using `Digest::SHA2.file(filename).hexdigest`). The second check avoids re-loading 'touched' files when the contents haven't changed.
- I haven't committed to the name yet, could use other suggestions.
- The tests provide 100% line-by-line coverage, across both `Simple` and `KeyValue` backends.
- My use-case for developing this backend module is to improve per-process memory-usage (and less important, startup time) of a large, heavily-localized Rails application loading ~500mb of localization data stored in .yml files, with minimal application changes.