### PR TITLE
Ignore `.ruby-version` file by `git`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ vendor/**/*
 pkg
 .bundle
 .rvmrc
+.ruby-version
 Gemfile.lock
 gemfiles/*.lock


### PR DESCRIPTION
It's a common format for `rbenv`, `rvm`, RuboCop, etc.