### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -13,6 +13,13 @@ Gem::Specification.new do |s|
   s.description  = "New wave Internationalization support for Ruby."
   s.license      = "MIT"
 
+  s.metadata     = {
+                     'bug_tracker_uri'   => 'https://github.com/svenfuchs/i18n/issues',
+                     'changelog_uri'     => 'https://github.com/svenfuchs/i18n/releases',
+                     'documentation_uri' => 'https://guides.rubyonrails.org/i18n.html',
+                     'source_code_uri'   => 'https://github.com/svenfuchs/i18n',
+                   }
+
   s.files        = Dir.glob("{gemfiles,lib,test}/**/**") + %w(README.md MIT-LICENSE)
   s.platform     = Gem::Platform::RUBY
   s.require_path = 'lib'


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, read documentation, raise issues and analyse the changelog. These links will appear on the rubygems page at https://rubygems.org/gems/i18n after the next release.