### PR TITLE
rm unused Kernel core_ext

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -2,7 +2,6 @@
 
 require 'yaml'
 require 'i18n/core_ext/hash'
-require 'i18n/core_ext/kernel/suppress_warnings'
 
 module I18n
   module Backend

--- a/lib/i18n/core_ext/kernel/suppress_warnings.rb
+++ b/lib/i18n/core_ext/kernel/suppress_warnings.rb
@@ -1,8 +1,0 @@
-module Kernel
-  def suppress_warnings
-    original_verbosity, $VERBOSE = $VERBOSE, nil
-    yield
-  ensure
-    $VERBOSE = original_verbosity
-  end
-end


### PR DESCRIPTION
This monkey patch is unused as of https://github.com/svenfuchs/i18n/commit/93dbfb621329c1eb544516533146b4f43d9360de#diff-3f17a1b2013dc8b6a9e8a58094b475f8L157