### PR TITLE
Add post_install_message about change of fallbacks

### DIFF
--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -40,7 +40,7 @@ If you're using I18n 1.1.x and Rails (< 6.0), this should be
 If not, fallbacks will be broken in your app by I18n 1.1.x.
 
 For more info see:
-https://github.com/svenfuchs/i18n/releases
+https://github.com/svenfuchs/i18n/releases/tag/v1.1.0
 
 END
 

--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -28,4 +28,20 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
 
   s.add_dependency 'concurrent-ruby', '~> 1.0'
+
+  s.post_install_message = <<-END
+
+HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
+But that may break your application.
+
+Please check your Rails app for 'config.i18n.fallbacks = true'.
+If you're using I18n 1.1.x and Rails (< 6.0), this should be
+'config.i18n.fallbacks = [I18n.default_locale]'.
+If not, fallbacks will be broken in your app by I18n 1.1.x.
+
+For more info see:
+https://github.com/svenfuchs/i18n/releases
+
+END
+
 end


### PR DESCRIPTION
We experienced problem with our projects by the change of fallbacks behavior.
We wanted to know the breaking change.

I want any users who will update i18n to know the change to avoid troubles.
I don't mind the detail(content) of `post_install_message`.
I borrowed an idea from the other popular gem haml.
https://github.com/haml/haml/blob/f699ca90cf5ce09f71035aebe8c3b6d67401ebfa/haml.gemspec#L37

Main issue:
https://github.com/svenfuchs/i18n/pull/415

Changes in Rails 6:
https://github.com/rails/rails/issues/34383
https://github.com/rails/rails/pull/33574

-----

Not all users are affected by the fallbacks issue. (Affected users are much less.)
So `post_install_message` could be too much because it will be displayed to all users.

The better alternative may be displaying warning message.

_lib/i18n/locale/fallbacks.rb_

```diff
@@ -56,7 +56,7 @@ module I18n
       def initialize(*mappings)
         @map = {}
         map(mappings.pop) if mappings.last.is_a?(Hash)
-        self.defaults = mappings.empty? ? [] : mappings
+        self.defaults = mappings.empty? ? empty_with_warning : mappings
       end

       def defaults=(defaults)
@@ -91,6 +91,13 @@ module I18n
         result.push(*defaults) if include_defaults
         result.uniq.compact
       end
+
+      private
+
+      def empty_with_warning
+        puts "Warning message"
+        []
+      end
     end
```

Rails introduced message but it doesn't help the majority of current Rails users who use Rails (< 6.0).
https://github.com/rails/rails/pull/33574/files

