### PR TITLE
Support integer keys with string lookup

### DIFF
--- a/lib/i18n.rb
+++ b/lib/i18n.rb
@@ -362,7 +362,18 @@ module I18n
         else
           keys = key.to_s.split(separator)
           keys.delete('')
-          keys.map! { |k| k.to_sym }
+          keys.map! do |k|
+            case k
+            when /\A[-+]?\d+\z/ # integer
+              k.to_i
+            when 'true'
+              true
+            when 'false'
+              false
+            else
+              k.to_sym
+            end
+          end
           keys
         end
     end

--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -88,8 +88,11 @@ module I18n
           keys = I18n.normalize_keys(locale, key, scope, options[:separator])
 
           keys.inject(translations) do |result, _key|
-            _key = _key.to_sym
-            return nil unless result.is_a?(Hash) && result.has_key?(_key)
+            return nil unless result.is_a?(Hash)
+            unless result.has_key?(_key)
+              _key = _key.to_s.to_sym
+              return nil unless result.has_key?(_key)
+            end
             result = result[_key]
             result = resolve(locale, _key, result, options.merge(:scope => nil)) if result.is_a?(Symbol)
             result

--- a/lib/i18n/core_ext/hash.rb
+++ b/lib/i18n/core_ext/hash.rb
@@ -30,14 +30,7 @@ module I18n
       private
 
       def symbolize_key(key)
-        case key
-        when String
-          key.to_sym
-        when Numeric
-          key.to_s.to_sym
-        else
-          key
-        end
+        key.respond_to?(:to_sym) ? key.to_sym : key
       end
     end
   end

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -18,6 +18,12 @@ class I18nBackendSimpleTest < I18n::TestCase
     assert_equal "No", I18n.t(:available)[false]
   end
 
+  test "simple backend translate: given integer as a key" do
+    store_translations :en, available: { 1 => "Yes", 2 => "No" }
+    assert_equal "Yes", I18n.t(:available)[1]
+    assert_equal "Yes", I18n.t('available.1')
+  end
+
   # loading translations
   test "simple load_translations: given an unknown file type it raises I18n::UnknownFileType" do
     assert_raise(I18n::UnknownFileType) { I18n.backend.load_translations("#{locales_dir}/en.xml") }

--- a/test/core_ext/hash_test.rb
+++ b/test/core_ext/hash_test.rb
@@ -12,7 +12,7 @@ class I18nCoreExtHashInterpolationTest < I18n::TestCase
 
   test "#deep_symbolize_keys with numeric keys" do
     hash = { 1 => { 2 => { 3 => 'bar' } } }
-    expected = { :"1" => { :"2" => { :"3" => 'bar' } } }
+    expected = { 1 => { 2 => { 3 => 'bar' } } }
     assert_equal expected, hash.deep_symbolize_keys
   end
 


### PR DESCRIPTION
Improves upon #444 by adding support for integer keys in subtree API (e.g., `I18n.t(:available)[1]`) alongside support for integer keys in the lookup API (`I18n.t('available.1')`).

(Note: not fully tested beyond the existing test-coverage, I'm not confident the change to `normalize_key` won't break non-`Simple` backends in subtle ways.)