### PR TITLE
Update post install message for rails 5.2.2 default behavior

### DIFF
--- a/i18n.gemspec
+++ b/i18n.gemspec
@@ -35,7 +35,7 @@ HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
 But that may break your application.
 
 Please check your Rails app for 'config.i18n.fallbacks = true'.
-If you're using I18n 1.1.x and Rails (< 6.0), this should be
+If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
 'config.i18n.fallbacks = [I18n.default_locale]'.
 If not, fallbacks will be broken in your app by I18n 1.1.x.
 


### PR DESCRIPTION
I believe that from rails 5.2.2, there was a change in the default behavior when 
 `config.i18n.fallbacks` was set to true.
https://github.com/rails/rails/pull/33574
https://github.com/rails/rails/commit/83d6aaa406566da6bbcc6d83244509e422a1a0fb

The change in rails provides compatibility, but I am guessing that since the pull request which added the post-install message ( https://github.com/svenfuchs/i18n/pull/442) had a link to this change, so I am wondering that there was something in mind not specifying 5.2.2 as the version.