### PR TITLE
Fix hash keys in array are not symbolized

### DIFF
--- a/lib/i18n/core_ext/hash.rb
+++ b/lib/i18n/core_ext/hash.rb
@@ -13,8 +13,7 @@ module I18n
 
       def deep_symbolize_keys
         each_with_object({}) do |(key, value), result|
-          value = value.deep_symbolize_keys if value.is_a?(Hash)
-          result[symbolize_key(key)] = value
+          result[symbolize_key(key)] = deep_symbolize_keys_in_object(value)
           result
         end
       end
@@ -29,6 +28,19 @@ module I18n
 
       def symbolize_key(key)
         key.respond_to?(:to_sym) ? key.to_sym : key
+      end
+
+      private
+
+      def deep_symbolize_keys_in_object(value)
+        case value
+        when Hash
+          value.deep_symbolize_keys
+        when Array
+          value.map { |e| deep_symbolize_keys_in_object(e) }
+        else
+          value
+        end
       end
     end
   end

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -24,6 +24,19 @@ class I18nBackendSimpleTest < I18n::TestCase
     assert_equal "Yes", I18n.t('available.1')
   end
 
+  test "simple backend translate: symbolize keys in hash" do
+    store_translations :en, nested_hashes_in_array: { hello: "world" }
+    assert_equal "world", I18n.t('nested_hashes_in_array.hello')
+    assert_equal "world", I18n.t('nested_hashes_in_array')[:hello]
+  end
+
+  test "simple backend translate: symbolize keys in array" do
+    store_translations :en, nested_hashes_in_array: [ { hello: "world" } ]
+    I18n.t('nested_hashes_in_array').each do |val|
+      assert_equal "world", val[:hello]
+    end
+  end
+
   # loading translations
   test "simple load_translations: given an unknown file type it raises I18n::UnknownFileType" do
     assert_raise(I18n::UnknownFileType) { I18n.backend.load_translations("#{locales_dir}/en.xml") }


### PR DESCRIPTION
Fixes #449 

949dc641d81773977e432626427aa0f8971a1073 makes `Hash#deep_symbolize_keys` defined by active support won't be used
And this gem's implementation ignores hashes in array (with no test coverage)

Using sample project https://github.com/tom-lord/i18n_regression produces the following result with this PR:
```
I18n Version: 1.3.0
"One"
true
false
"world"
{:composite=>[{1=>"One", true=>true, false=>false, :hello=>"world"}]}
[{1=>"One", true=>true, false=>false, :hello=>"world"}]
```