### PR TITLE
have refine block use the module defined in during method calls (for …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,4 @@ matrix:
       gemfile: gemfiles/Gemfile.rails-master
   allow_failures:
     - rvm: rbx
-    - rvm: jruby
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'mocha'
-gem 'test_declarative'
+gem 'mocha', '~> 1.7.0'
+gem 'test_declarative', '0.0.6'
 gem 'rake', '~> 12.2.1'
-gem 'minitest'
+gem 'minitest', '~> 5.1'
 gem 'json'

--- a/gemfiles/Gemfile.rails-3.2.x
+++ b/gemfiles/Gemfile.rails-3.2.x
@@ -7,4 +7,7 @@ gem 'mocha'
 gem 'test_declarative'
 gem 'rake'
 gem 'minitest'
-gem 'oj'
+
+platforms :mri do
+  gem 'oj'
+end

--- a/gemfiles/Gemfile.rails-3.2.x
+++ b/gemfiles/Gemfile.rails-3.2.x
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', '~> 3.2.0'
-gem 'mocha'
-gem 'test_declarative'
-gem 'rake'
-gem 'minitest'
+gem 'mocha', '~> 1.7.0'
+gem 'test_declarative', '0.0.6'
+gem 'rake', '~> 12.2.1'
+gem 'minitest', '~> 5.1'
 
 platforms :mri do
   gem 'oj'

--- a/gemfiles/Gemfile.rails-4.0.x
+++ b/gemfiles/Gemfile.rails-4.0.x
@@ -7,4 +7,7 @@ gem 'mocha'
 gem 'test_declarative'
 gem 'rake'
 gem 'minitest'
-gem 'oj'
+
+platforms :mri do
+  gem 'oj'
+end

--- a/gemfiles/Gemfile.rails-4.0.x
+++ b/gemfiles/Gemfile.rails-4.0.x
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', '~> 4.0.0'
-gem 'mocha'
-gem 'test_declarative'
-gem 'rake'
-gem 'minitest'
+gem 'mocha', '~> 1.7.0'
+gem 'test_declarative', '0.0.6'
+gem 'rake', '~> 12.2.1'
+gem 'minitest', '~> 4.2'
 
 platforms :mri do
   gem 'oj'

--- a/gemfiles/Gemfile.rails-4.1.x
+++ b/gemfiles/Gemfile.rails-4.1.x
@@ -3,8 +3,11 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', '~> 4.1.0'
-gem 'mocha'
-gem 'test_declarative'
-gem 'rake'
-gem 'minitest'
-gem 'oj'
+gem 'mocha', '~> 1.7.0'
+gem 'test_declarative', '0.0.6'
+gem 'rake', '~> 12.2.1'
+gem 'minitest', '~> 5.1'
+
+platforms :mri do
+  gem 'oj'
+end

--- a/gemfiles/Gemfile.rails-4.2.x
+++ b/gemfiles/Gemfile.rails-4.2.x
@@ -7,4 +7,7 @@ gem 'mocha'
 gem 'test_declarative'
 gem 'rake'
 gem 'minitest'
-gem 'oj'
+
+platforms :mri do
+  gem 'oj'
+end

--- a/gemfiles/Gemfile.rails-4.2.x
+++ b/gemfiles/Gemfile.rails-4.2.x
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', '~> 4.2.0'
-gem 'mocha'
-gem 'test_declarative'
-gem 'rake'
-gem 'minitest'
+gem 'mocha', '~> 1.7.0'
+gem 'test_declarative', '0.0.6'
+gem 'rake', '~> 12.2.1'
+gem 'minitest', '~> 5.1'
 
 platforms :mri do
   gem 'oj'

--- a/gemfiles/Gemfile.rails-5.0.x
+++ b/gemfiles/Gemfile.rails-5.0.x
@@ -7,4 +7,7 @@ gem 'mocha'
 gem 'test_declarative'
 gem 'rake'
 gem 'minitest'
-gem 'oj'
+
+platforms :mri do
+  gem 'oj'
+end

--- a/gemfiles/Gemfile.rails-5.0.x
+++ b/gemfiles/Gemfile.rails-5.0.x
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', '~> 5.0.0'
-gem 'mocha'
-gem 'test_declarative'
-gem 'rake'
-gem 'minitest'
+gem 'mocha', '~> 1.7.0'
+gem 'test_declarative', '0.0.6'
+gem 'rake', '~> 12.2.1'
+gem 'minitest', '~> 5.1'
 
 platforms :mri do
   gem 'oj'

--- a/gemfiles/Gemfile.rails-5.1.x
+++ b/gemfiles/Gemfile.rails-5.1.x
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', '~> 5.1.0'
-gem 'mocha'
-gem 'test_declarative'
-gem 'rake'
-gem 'minitest'
+gem 'mocha', '~> 1.7.0'
+gem 'test_declarative', '0.0.6'
+gem 'rake', '~> 12.2.1'
+gem 'minitest', '~> 5.1'
 
 platforms :mri do
   gem 'oj'

--- a/gemfiles/Gemfile.rails-5.1.x
+++ b/gemfiles/Gemfile.rails-5.1.x
@@ -7,4 +7,7 @@ gem 'mocha'
 gem 'test_declarative'
 gem 'rake'
 gem 'minitest'
-gem 'oj'
+
+platforms :mri do
+  gem 'oj'
+end

--- a/gemfiles/Gemfile.rails-5.2.x
+++ b/gemfiles/Gemfile.rails-5.2.x
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', '~> 5.2.0'
-gem 'mocha'
-gem 'test_declarative'
-gem 'rake'
-gem 'minitest'
+gem 'mocha', '~> 1.7.0'
+gem 'test_declarative', '0.0.6'
+gem 'rake', '~> 12.2.1'
+gem 'minitest', '~> 5.1'
 
 platforms :mri do
   gem 'oj'

--- a/gemfiles/Gemfile.rails-5.2.x
+++ b/gemfiles/Gemfile.rails-5.2.x
@@ -7,4 +7,7 @@ gem 'mocha'
 gem 'test_declarative'
 gem 'rake'
 gem 'minitest'
-gem 'oj'
+
+platforms :mri do
+  gem 'oj'
+end

--- a/gemfiles/Gemfile.rails-master
+++ b/gemfiles/Gemfile.rails-master
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'activesupport', github: 'rails/rails', branch: 'master'
-gem 'mocha'
-gem 'test_declarative'
-gem 'rake'
-gem 'minitest'
+gem 'mocha', '~> 1.7.0'
+gem 'test_declarative', '0.0.6'
+gem 'rake', '~> 12.2.1'
+gem 'minitest', '~> 5.1'
 
 platforms :mri do
   gem 'oj'

--- a/gemfiles/Gemfile.rails-master
+++ b/gemfiles/Gemfile.rails-master
@@ -7,4 +7,7 @@ gem 'mocha'
 gem 'test_declarative'
 gem 'rake'
 gem 'minitest'
-gem 'oj'
+
+platforms :mri do
+  gem 'oj'
+end

--- a/lib/i18n/core_ext/hash.rb
+++ b/lib/i18n/core_ext/hash.rb
@@ -1,6 +1,8 @@
 module I18n
   module HashRefinements
     refine Hash do
+      using I18n::HashRefinements
+
       def slice(*keep_keys)
         h = {}
         keep_keys.each { |key| h[key] = fetch(key) if has_key?(key) }


### PR DESCRIPTION
…Jruby)

Fixes #447 

based on feedback from https://github.com/jruby/jruby/issues/5054

the `refine` block need to be extended to use it's refinements if the method calls are to use the new methods (also works on MRI)